### PR TITLE
PIM-417: PIM | Export Template | Add the ability to load multiple templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ app.post('/export/pim/product', (req, res) => {
 app.post('/export/legacy/pim/product', (req, res) => {
   try {
     LegacyExportPim(req);
-    console.log('reqBody: ', req.body);
     res.status(200).send('');
   } catch (err) {
     res.status(400).send('');

--- a/index.js
+++ b/index.js
@@ -1,60 +1,60 @@
 /* eslint-disable no-undef */
 const express = require('express');
-const app = express()
+const app = express();
 const bodyParser = require('body-parser');
 const helmet = require('helmet');
 
 // app Configuration
-const bodySize = '80mb'
-app.use(bodyParser.json({ limit: bodySize }))
-app.use(bodyParser.urlencoded({ extended: false, limit: bodySize }))
+const bodySize = '80mb';
+app.use(bodyParser.json({ limit: bodySize }));
+app.use(bodyParser.urlencoded({ extended: false, limit: bodySize }));
 app.use(helmet.frameguard());
-module.exports = app.listen((process.env.PORT || 5001))
+module.exports = app.listen(process.env.PORT || 5001);
 
 /**
  * objects used in routes
  */
-const ImportCategory = require('./lib/ImportCategory')
-const ImportProduct = require('./lib/ImportProduct')
-const ExportPim = require('./lib/ExportProduct')
+const ImportCategory = require('./lib/ImportCategory');
+const ImportProduct = require('./lib/ImportProduct');
+const ExportPim = require('./lib/ExportProduct');
 
-const LegacyExportPim = require('./legacy/ExportPIM')
+const LegacyExportPim = require('./legacy/ExportPIM');
 
-const ERROR_OBJ = { message: '', success: false }
-const SUCCESS_OBJ = { message: 'Request received', success: true }
+const ERROR_OBJ = { message: '', success: false };
+const SUCCESS_OBJ = { message: 'Request received', success: true };
 
 /**
  * routes for our node app
  */
 app.get('/', (req, res) => {
-  res.status(200).send('Propel PIM data server is running.')
-})
+  res.status(200).send('Propel PIM data server is running.');
+});
 
 /**
  * route for importing pim categories
  */
 app.post('/import/pim/category', (req, res) => {
   try {
-    new ImportCategory(req, res)
-    res.status(200).send(SUCCESS_OBJ)
-  } catch(error) {
-    ERROR_OBJ.message = error
-    res.status(400).send(ERROR_OBJ)
+    new ImportCategory(req, res);
+    res.status(200).send(SUCCESS_OBJ);
+  } catch (error) {
+    ERROR_OBJ.message = error;
+    res.status(400).send(ERROR_OBJ);
   }
-})
+});
 
-  /**
+/**
  * route for importing pim products
  */
 app.post('/import/pim/product', (req, res) => {
   try {
-    new ImportProduct(req, res)
-    res.status(200).send(SUCCESS_OBJ)
-  } catch(error) {
-    ERROR_OBJ.message = error
-    res.status(400).send(ERROR_OBJ)
+    new ImportProduct(req, res);
+    res.status(200).send(SUCCESS_OBJ);
+  } catch (error) {
+    ERROR_OBJ.message = error;
+    res.status(400).send(ERROR_OBJ);
   }
-})
+});
 
 /**
  * route for exporting pim products
@@ -64,10 +64,10 @@ app.post('/export/pim/product', (req, res) => {
     new ExportPim(req);
     res.status(200).send(SUCCESS_OBJ);
   } catch (error) {
-    ERROR_OBJ.message = error
+    ERROR_OBJ.message = error;
     res.status(400).send(ERROR_OBJ);
   }
-})
+});
 
 /**
  * route for legacy exporter
@@ -75,8 +75,9 @@ app.post('/export/pim/product', (req, res) => {
 app.post('/export/legacy/pim/product', (req, res) => {
   try {
     LegacyExportPim(req);
-    res.status(200).send('')
+    console.log('reqBody: ', req.body);
+    res.status(200).send('');
   } catch (err) {
-    res.status(400).send('')
+    res.status(400).send('');
   }
-})
+});

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -14,8 +14,8 @@ async function LegacyExportPIM(req) {
   let recordsAndCols;
   try {
     recordsAndCols = await PimStructure(reqBody, isListPageExport);
-  } catch (error) {
-    console.log('error: ', error);
+  } catch (err) {
+    console.log('error: ', err);
   }
   let csvString = convertArrayOfObjectsToCSV(
     recordsAndCols[0],

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -14,8 +14,8 @@ async function LegacyExportPIM(req) {
   let recordsAndCols;
   try {
     recordsAndCols = await PimStructure(reqBody, isListPageExport);
-  } catch (err) {
-    console.log('error: ', err);
+  } catch (error) {
+    console.log('error: ', error);
   }
   let csvString = convertArrayOfObjectsToCSV(
     recordsAndCols[0],
@@ -79,7 +79,7 @@ function convertArrayOfObjectsToCSV(records, columns) {
 
   // in the keys valirable store fields API Names as a key
   // this labels use in CSV file header
-  columns.forEach(col => {
+  columns.forEach((col) => {
     if (col.fieldName) {
       if (col.fieldName === 'ProductLink') {
         keys.push(col.typeAttributes.label.fieldName);

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -79,7 +79,7 @@ function convertArrayOfObjectsToCSV(records, columns) {
 
   // in the keys valirable store fields API Names as a key
   // this labels use in CSV file header
-  columns.forEach((col) => {
+  columns.forEach(col => {
     if (col.fieldName) {
       if (col.fieldName === 'ProductLink') {
         keys.push(col.typeAttributes.label.fieldName);

--- a/legacy/PimProductListHelper.js
+++ b/legacy/PimProductListHelper.js
@@ -120,14 +120,8 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
     templateFields = templateRows[1].split(',');
     for (let i = 0; i < templateFields.length; i++) {
       if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
-        // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
-        templateFields[i] = templateFields[i].split('"');
-        templateFields[i] =
-          templateFields[i][Math.floor(templateFields[i].length / 2)];
-        if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
-          templateFields[i] = templateFields[i].slice(11, -1);
-        }
-        templateFields[i] = 'PROPEL_ATT(' + templateFields[i] + ')';
+        // remove double quotes (note the 3 different kinds of double quotes in the regex)
+        templateFields[i] = templateFields[i].replace(/["“”]+/g, '');
       }
     }
   }

--- a/legacy/PimProductListHelper.js
+++ b/legacy/PimProductListHelper.js
@@ -29,7 +29,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
 
   // filter the records if rows were selected or filters applied in product list page
   let filteredRecords = [];
-  exportRecords.forEach((record) => {
+  exportRecords.forEach(record => {
     if (
       recordIds.includes(record.get('Id')) ||
       vvIds.includes(record.get('Id'))
@@ -56,7 +56,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
     let attributeResults = new Map();
     if (variantValueIds.size > 0) {
       variantValueIds = Array.from(variantValueIds);
-      variantValueIds = variantValueIds.map((id) => `'${id}'`).join(',');
+      variantValueIds = variantValueIds.map(id => `'${id}'`).join(',');
       let variantValues = await service.queryExtend(
         helper.namespaceQuery(
           `select Id, Variant__r.Product__c
@@ -66,11 +66,11 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
         ),
         variantValueIds.split(',')
       );
-      variantValues.forEach((value) => {
+      variantValues.forEach(value => {
         productIdSet.add(helper.getValue(value, 'Variant__r.Product__c'));
       });
       const productIds = Array.from(productIdSet)
-        .map((id) => `'${id}'`)
+        .map(id => `'${id}'`)
         .join(',');
       let productsList = await PimProductManager(productIds, helper, service);
       let productMap = await getProductMap(productsList);
@@ -90,10 +90,10 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
     // for each key of attribute results (Product__c Id or Variant_Value__c Id)
     if (attributeResults.size > 0) {
       const productIdKeys = Array.from(attributeResults.keys());
-      productIdKeys.forEach((productId) => {
+      productIdKeys.forEach(productId => {
         if (attributeResults.get(productId) !== null) {
           // check list of export records if there is a Map with a matching Id
-          exportRecordsAndColumns[0].forEach((exportRecord) => {
+          exportRecordsAndColumns[0].forEach(exportRecord => {
             if (exportRecord.get('Id') === productId) {
               // add attribute labels and values from attributeResults into corresponding export record
               const labels = Array.from(attributeResults.get(productId).keys());
@@ -160,7 +160,7 @@ async function getRecordByCategory(reqBody, pqlBuilder, isPrimaryCategory) {
 
 async function getCategoryPrimaryStatus(categoryId) {
   let categoryIdList = [categoryId];
-  categoryIdList = categoryIdList.map((id) => `'${id}'`).join(',');
+  categoryIdList = categoryIdList.map(id => `'${id}'`).join(',');
   const categoryList = await service.simpleQuery(
     helper.namespaceQuery(
       `select Id, Is_Primary__c
@@ -183,10 +183,10 @@ async function getAllChildrenIds(cm) {
     tempCategories = await categoryChildrenQuery(nextIds);
     nextIds = new Set();
 
-    tempCategories.forEach((cat) => {
+    tempCategories.forEach(cat => {
       nextIds.add(cat.Id);
     });
-    nextIds.forEach((id) => {
+    nextIds.forEach(id => {
       cm.allChildrenIds.add(id);
     });
   }
@@ -197,10 +197,10 @@ async function getAllChildrenIds(cm) {
 async function categoryChildrenQuery(pParentIds) {
   try {
     let listParentIds = [];
-    pParentIds.forEach((id) => {
+    pParentIds.forEach(id => {
       listParentIds.push(id);
     });
-    listParentIds = listParentIds.map((id) => `'${id}'`).join(',');
+    listParentIds = listParentIds.map(id => `'${id}'`).join(',');
     return await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Name, Parent__c
@@ -220,10 +220,10 @@ async function buildStructureWithCategoryIds(pCategoryIds) {
     throw 'No Category Ids';
   }
   let listCategoryIds = [];
-  pCategoryIds.forEach((id) => {
+  pCategoryIds.forEach(id => {
     listCategoryIds.push(id);
   });
-  listCategoryIds = listCategoryIds.map((id) => `'${id}'`).join(',');
+  listCategoryIds = listCategoryIds.map(id => `'${id}'`).join(',');
   // return productsList
   return await service.simpleQuery(
     helper.namespaceQuery(
@@ -273,10 +273,10 @@ async function buildStructureWithSecondaryCategoryIds(pCategoryIds) {
     throw 'No Category Ids';
   }
   let listCategoryIds = [];
-  pCategoryIds.forEach((id) => {
+  pCategoryIds.forEach(id => {
     listCategoryIds.push(id);
   });
-  listCategoryIds = listCategoryIds.map((id) => `'${id}'`).join(',');
+  listCategoryIds = listCategoryIds.map(id => `'${id}'`).join(',');
   let links = await service.simpleQuery(
     helper.namespaceQuery(
       `select Id, Product__c
@@ -287,10 +287,10 @@ async function buildStructureWithSecondaryCategoryIds(pCategoryIds) {
 
   if (links.size > 0) {
     let productIds = [];
-    links.forEach((link) => {
+    links.forEach(link => {
       productIds.push(helper.getValue(link, 'Product__c'));
     });
-    productIds = productIds.map((id) => `'${id}'`).join(',');
+    productIds = productIds.map(id => `'${id}'`).join(',');
     // return productsList
     return await service.simpleQuery(
       helper.namespaceQuery(
@@ -338,7 +338,7 @@ async function buildStructureWithSecondaryCategoryIds(pCategoryIds) {
 // PIM repo ProductManager.getProductMap
 async function getProductMap(productsList) {
   let productMap = new Map();
-  productsList.forEach((product) => {
+  productsList.forEach(product => {
     productMap.set(product.Id, product);
   });
   return productMap;
@@ -354,10 +354,10 @@ async function getResultForProductMap(
   let tempMap = new Map();
   let variantToAttributeMap = await getVariantMap(productsList);
 
-  Array.from(productMap.values()).forEach((product) => {
+  Array.from(productMap.values()).forEach(product => {
     tempMap = new Map();
     if (helper.getValue(product, 'Attributes__r') !== null) {
-      helper.getValue(product, 'Attributes__r').records.forEach((attribute) => {
+      helper.getValue(product, 'Attributes__r').records.forEach(attribute => {
         if (
           helper.getValue(attribute, 'Overwritten_Variant_Value__c') === null &&
           helper.getValue(attribute, 'Attribute_Label__r') !== null
@@ -376,7 +376,7 @@ async function getResultForProductMap(
   let tempVariantValue;
   let tempVariantMap = new Map();
   variantValueIds = variantValueIds.replace(/'/g, '').split(',');
-  variantValueIds.forEach((vvId) => {
+  variantValueIds.forEach(vvId => {
     tempVariantValue = variantValueDetailMap.get(vvId);
     tempVariantMap = new Map(
       results.get(helper.getValue(tempVariantValue, 'Variant__r.Product__c'))
@@ -386,10 +386,10 @@ async function getResultForProductMap(
       helper
         .getValue(tempVariantValue, 'Parent_Value_Path__c')
         .split(',')
-        .forEach((pathVVId) => {
+        .forEach(pathVVId => {
           // for each parent, add their overwritten attribute values
           if (variantToAttributeMap.has(pathVVId)) {
-            variantToAttributeMap.get(pathVVId).forEach((attribute) => {
+            variantToAttributeMap.get(pathVVId).forEach(attribute => {
               tempVariantMap.set(
                 helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
                 helper.getValue(attribute, 'Value__c')
@@ -400,7 +400,7 @@ async function getResultForProductMap(
     }
 
     if (variantToAttributeMap.has(vvId)) {
-      variantToAttributeMap.get(vvId).forEach((attribute) => {
+      variantToAttributeMap.get(vvId).forEach(attribute => {
         if (helper.getValue(attribute, 'Attribute_Label__r')) {
           tempVariantMap.set(
             helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
@@ -417,9 +417,9 @@ async function getResultForProductMap(
 // PIM repo ProductManager.getVariantMap()
 async function getVariantMap(productsList) {
   let variantMap = new Map();
-  productsList.forEach((product) => {
+  productsList.forEach(product => {
     if (helper.getValue(product, 'Attributes__r') !== null) {
-      helper.getValue(product, 'Attributes__r').records.forEach((attribute) => {
+      helper.getValue(product, 'Attributes__r').records.forEach(attribute => {
         // iterate through each product's Attribute_Value__c
         if (
           helper.getValue(attribute, 'Overwritten_Variant_Value__c') !== null
@@ -457,10 +457,10 @@ async function getVariantMap(productsList) {
 // PIM repo ProductManager.getVariantValueDetailMap()
 async function getVariantValueDetailMap(productsList) {
   let productIdList = [];
-  productsList.forEach((product) => {
+  productsList.forEach(product => {
     productIdList.push(product.Id);
   });
-  productIdList = productIdList.map((id) => `'${id}'`).join(',');
+  productIdList = productIdList.map(id => `'${id}'`).join(',');
   let variantValueMap = new Map();
   const variantValueList = await service.simpleQuery(
     helper.namespaceQuery(
@@ -469,7 +469,7 @@ async function getVariantValueDetailMap(productsList) {
       where Variant__r.Product__c IN (${productIdList})`
     )
   );
-  variantValueList.forEach((value) => {
+  variantValueList.forEach(value => {
     variantValueMap.set(value.Id, value);
   });
   return variantValueMap;
@@ -492,7 +492,7 @@ async function addExportColumns(
 
   // populate default columns first if not templated export
   if (!templateFields || templateFields.length === 0) {
-    Array.from(defaultColumns.keys()).forEach((defaultCol) => {
+    Array.from(defaultColumns.keys()).forEach(defaultCol => {
       exportColumns.push({
         fieldName: defaultColumns.get(defaultCol),
         label: defaultCol,
@@ -507,12 +507,12 @@ async function addExportColumns(
   let linkedGroupsChildren = [];
   let columnAttributeIds = new Set();
   if (linkedAttributes.length > 0) {
-    linkedAttributes.forEach((attr) => {
+    linkedAttributes.forEach(attr => {
       columnAttributeIds.add(attr);
     });
   }
   if (linkedGroups.length > 0) {
-    linkedGroups = linkedGroups.map((id) => `'${id}'`).join(',');
+    linkedGroups = linkedGroups.map(id => `'${id}'`).join(',');
     linkedGroupsChildren = await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Name, Attribute_Group__c
@@ -520,13 +520,13 @@ async function addExportColumns(
         where Attribute_Group__c IN (${linkedGroups})`
       )
     );
-    linkedGroupsChildren.forEach((childAttr) => {
+    linkedGroupsChildren.forEach(childAttr => {
       columnAttributeIds.add(childAttr.Id);
     });
   }
   if (columnAttributeIds.size > 0) {
     columnAttributeIds = Array.from(columnAttributeIds);
-    columnAttributeIds = columnAttributeIds.map((id) => `'${id}'`).join(',');
+    columnAttributeIds = columnAttributeIds.map(id => `'${id}'`).join(',');
 
     // get SOQL query for Label__c of all attribute labels
     const columnAttributes = await service.simpleQuery(
@@ -538,7 +538,7 @@ async function addExportColumns(
     );
 
     // add these attributes as columns to export
-    columnAttributes.forEach((attr) => {
+    columnAttributes.forEach(attr => {
       exportColumns.push({
         fieldName: helper.getValue(attr, 'Primary_Key__c'),
         label: helper.getValue(attr, 'Label__c'),
@@ -556,7 +556,7 @@ async function addExportColumns(
     );
 
     if (!templateFields || templateFields.length === 0) {
-      columnAttributes.forEach((attr) => {
+      columnAttributes.forEach(attr => {
         // if not template export, push all attribute columns
         exportColumns.push({
           fieldName: helper.getValue(attr, 'Primary_Key__c'),
@@ -585,7 +585,7 @@ async function addExportColumns(
         } else if (isAttributeField && !isDefaultColumn) {
           // value specified in template is a field's value, and col in template is an attribute column
           field = field.slice(11, -1);
-          columnAttributes.forEach((colAttr) => {
+          columnAttributes.forEach(colAttr => {
             if (helper.getValue(colAttr, 'Label__c') === field) {
               exportColumns.push({
                 fieldName: helper.getValue(colAttr, 'Primary_Key__c'),
@@ -607,8 +607,8 @@ async function addExportColumns(
     }
   }
   // populate export records with raw values specified in the template
-  Array.from(templateHeaderValueMap.keys()).forEach((header) => {
-    exportRecordsAndColumns[0].forEach((recordMap) => {
+  Array.from(templateHeaderValueMap.keys()).forEach(header => {
+    exportRecordsAndColumns[0].forEach(recordMap => {
       recordMap.set(header, templateHeaderValueMap.get(header));
     });
   });

--- a/legacy/PimProductListHelper.js
+++ b/legacy/PimProductListHelper.js
@@ -115,7 +115,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
   let templateHeaders;
   if (reqBody.options.isTemplateExport && reqBody.templateVersionData) {
     // parse headers and fields and store them in a map
-    const templateRows = reqBody.templateVersionData.split('\n');
+    const templateRows = reqBody.templateVersionData.split(/\r?\n/);
     templateHeaders = templateRows[0].split(',');
     templateFields = templateRows[1].split(',');
     for (let i = 0; i < templateFields.length; i++) {

--- a/legacy/PimProductListHelper.js
+++ b/legacy/PimProductListHelper.js
@@ -17,7 +17,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
   /** PIM repo ProductService.productStructureByCategory start */
   let pqlBuilder = {
     objectType: 'CATEGORY',
-    objectId: categoryId,
+    objectId: categoryId
   };
 
   // PIM repo ProductPQLHelper.getRecordByCategory()
@@ -29,7 +29,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
 
   // filter the records if rows were selected or filters applied in product list page
   let filteredRecords = [];
-  exportRecords.forEach(record => {
+  exportRecords.forEach((record) => {
     if (
       recordIds.includes(record.get('Id')) ||
       vvIds.includes(record.get('Id'))
@@ -56,7 +56,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
     let attributeResults = new Map();
     if (variantValueIds.size > 0) {
       variantValueIds = Array.from(variantValueIds);
-      variantValueIds = variantValueIds.map(id => `'${id}'`).join(',');
+      variantValueIds = variantValueIds.map((id) => `'${id}'`).join(',');
       let variantValues = await service.queryExtend(
         helper.namespaceQuery(
           `select Id, Variant__r.Product__c
@@ -66,11 +66,11 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
         ),
         variantValueIds.split(',')
       );
-      variantValues.forEach(value => {
+      variantValues.forEach((value) => {
         productIdSet.add(helper.getValue(value, 'Variant__r.Product__c'));
       });
       const productIds = Array.from(productIdSet)
-        .map(id => `'${id}'`)
+        .map((id) => `'${id}'`)
         .join(',');
       let productsList = await PimProductManager(productIds, helper, service);
       let productMap = await getProductMap(productsList);
@@ -90,10 +90,10 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
     // for each key of attribute results (Product__c Id or Variant_Value__c Id)
     if (attributeResults.size > 0) {
       const productIdKeys = Array.from(attributeResults.keys());
-      productIdKeys.forEach(productId => {
+      productIdKeys.forEach((productId) => {
         if (attributeResults.get(productId) !== null) {
           // check list of export records if there is a Map with a matching Id
-          exportRecordsAndColumns[0].forEach(exportRecord => {
+          exportRecordsAndColumns[0].forEach((exportRecord) => {
             if (exportRecord.get('Id') === productId) {
               // add attribute labels and values from attributeResults into corresponding export record
               const labels = Array.from(attributeResults.get(productId).keys());
@@ -150,7 +150,7 @@ async function getRecordByCategory(reqBody, pqlBuilder, isPrimaryCategory) {
   let cm = {
     allChildrenIds: new Set(),
     allParentIds: new Set(),
-    startingCategoryId: pqlBuilder.objectId,
+    startingCategoryId: pqlBuilder.objectId
   };
   isPrimaryCategory = await getCategoryPrimaryStatus(pqlBuilder.objectId);
   let childrenIds = await getAllChildrenIds(cm);
@@ -166,7 +166,7 @@ async function getRecordByCategory(reqBody, pqlBuilder, isPrimaryCategory) {
 
 async function getCategoryPrimaryStatus(categoryId) {
   let categoryIdList = [categoryId];
-  categoryIdList = categoryIdList.map(id => `'${id}'`).join(',');
+  categoryIdList = categoryIdList.map((id) => `'${id}'`).join(',');
   const categoryList = await service.simpleQuery(
     helper.namespaceQuery(
       `select Id, Is_Primary__c
@@ -189,10 +189,10 @@ async function getAllChildrenIds(cm) {
     tempCategories = await categoryChildrenQuery(nextIds);
     nextIds = new Set();
 
-    tempCategories.forEach(cat => {
+    tempCategories.forEach((cat) => {
       nextIds.add(cat.Id);
     });
-    nextIds.forEach(id => {
+    nextIds.forEach((id) => {
       cm.allChildrenIds.add(id);
     });
   }
@@ -203,10 +203,10 @@ async function getAllChildrenIds(cm) {
 async function categoryChildrenQuery(pParentIds) {
   try {
     let listParentIds = [];
-    pParentIds.forEach(id => {
+    pParentIds.forEach((id) => {
       listParentIds.push(id);
     });
-    listParentIds = listParentIds.map(id => `'${id}'`).join(',');
+    listParentIds = listParentIds.map((id) => `'${id}'`).join(',');
     return await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Name, Parent__c
@@ -215,8 +215,8 @@ async function categoryChildrenQuery(pParentIds) {
       `
       )
     );
-  } catch (errorMsg) {
-    console.error(errorMsg);
+  } catch (err) {
+    console.error(err);
   }
 }
 
@@ -226,10 +226,10 @@ async function buildStructureWithCategoryIds(pCategoryIds) {
     throw 'No Category Ids';
   }
   let listCategoryIds = [];
-  pCategoryIds.forEach(id => {
+  pCategoryIds.forEach((id) => {
     listCategoryIds.push(id);
   });
-  listCategoryIds = listCategoryIds.map(id => `'${id}'`).join(',');
+  listCategoryIds = listCategoryIds.map((id) => `'${id}'`).join(',');
   // return productsList
   return await service.simpleQuery(
     helper.namespaceQuery(
@@ -279,10 +279,10 @@ async function buildStructureWithSecondaryCategoryIds(pCategoryIds) {
     throw 'No Category Ids';
   }
   let listCategoryIds = [];
-  pCategoryIds.forEach(id => {
+  pCategoryIds.forEach((id) => {
     listCategoryIds.push(id);
   });
-  listCategoryIds = listCategoryIds.map(id => `'${id}'`).join(',');
+  listCategoryIds = listCategoryIds.map((id) => `'${id}'`).join(',');
   let links = await service.simpleQuery(
     helper.namespaceQuery(
       `select Id, Product__c
@@ -293,10 +293,10 @@ async function buildStructureWithSecondaryCategoryIds(pCategoryIds) {
 
   if (links.size > 0) {
     let productIds = [];
-    links.forEach(link => {
+    links.forEach((link) => {
       productIds.push(helper.getValue(link, 'Product__c'));
     });
-    productIds = productIds.map(id => `'${id}'`).join(',');
+    productIds = productIds.map((id) => `'${id}'`).join(',');
     // return productsList
     return await service.simpleQuery(
       helper.namespaceQuery(
@@ -344,7 +344,7 @@ async function buildStructureWithSecondaryCategoryIds(pCategoryIds) {
 // PIM repo ProductManager.getProductMap
 async function getProductMap(productsList) {
   let productMap = new Map();
-  productsList.forEach(product => {
+  productsList.forEach((product) => {
     productMap.set(product.Id, product);
   });
   return productMap;
@@ -360,10 +360,10 @@ async function getResultForProductMap(
   let tempMap = new Map();
   let variantToAttributeMap = await getVariantMap(productsList);
 
-  Array.from(productMap.values()).forEach(product => {
+  Array.from(productMap.values()).forEach((product) => {
     tempMap = new Map();
     if (helper.getValue(product, 'Attributes__r') !== null) {
-      helper.getValue(product, 'Attributes__r').records.forEach(attribute => {
+      helper.getValue(product, 'Attributes__r').records.forEach((attribute) => {
         if (
           helper.getValue(attribute, 'Overwritten_Variant_Value__c') === null &&
           helper.getValue(attribute, 'Attribute_Label__r') !== null
@@ -382,7 +382,7 @@ async function getResultForProductMap(
   let tempVariantValue;
   let tempVariantMap = new Map();
   variantValueIds = variantValueIds.replace(/'/g, '').split(',');
-  variantValueIds.forEach(vvId => {
+  variantValueIds.forEach((vvId) => {
     tempVariantValue = variantValueDetailMap.get(vvId);
     tempVariantMap = new Map(
       results.get(helper.getValue(tempVariantValue, 'Variant__r.Product__c'))
@@ -392,10 +392,10 @@ async function getResultForProductMap(
       helper
         .getValue(tempVariantValue, 'Parent_Value_Path__c')
         .split(',')
-        .forEach(pathVVId => {
+        .forEach((pathVVId) => {
           // for each parent, add their overwritten attribute values
           if (variantToAttributeMap.has(pathVVId)) {
-            variantToAttributeMap.get(pathVVId).forEach(attribute => {
+            variantToAttributeMap.get(pathVVId).forEach((attribute) => {
               tempVariantMap.set(
                 helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
                 helper.getValue(attribute, 'Value__c')
@@ -406,7 +406,7 @@ async function getResultForProductMap(
     }
 
     if (variantToAttributeMap.has(vvId)) {
-      variantToAttributeMap.get(vvId).forEach(attribute => {
+      variantToAttributeMap.get(vvId).forEach((attribute) => {
         if (helper.getValue(attribute, 'Attribute_Label__r')) {
           tempVariantMap.set(
             helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
@@ -423,9 +423,9 @@ async function getResultForProductMap(
 // PIM repo ProductManager.getVariantMap()
 async function getVariantMap(productsList) {
   let variantMap = new Map();
-  productsList.forEach(product => {
+  productsList.forEach((product) => {
     if (helper.getValue(product, 'Attributes__r') !== null) {
-      helper.getValue(product, 'Attributes__r').records.forEach(attribute => {
+      helper.getValue(product, 'Attributes__r').records.forEach((attribute) => {
         // iterate through each product's Attribute_Value__c
         if (
           helper.getValue(attribute, 'Overwritten_Variant_Value__c') !== null
@@ -443,7 +443,7 @@ async function getVariantMap(productsList) {
                 ...variantMap.get(
                   helper.getValue(attribute, 'Overwritten_Variant_Value__c')
                 ),
-                attribute,
+                attribute
               ]
             );
           } else {
@@ -463,10 +463,10 @@ async function getVariantMap(productsList) {
 // PIM repo ProductManager.getVariantValueDetailMap()
 async function getVariantValueDetailMap(productsList) {
   let productIdList = [];
-  productsList.forEach(product => {
+  productsList.forEach((product) => {
     productIdList.push(product.Id);
   });
-  productIdList = productIdList.map(id => `'${id}'`).join(',');
+  productIdList = productIdList.map((id) => `'${id}'`).join(',');
   let variantValueMap = new Map();
   const variantValueList = await service.simpleQuery(
     helper.namespaceQuery(
@@ -475,7 +475,7 @@ async function getVariantValueDetailMap(productsList) {
       where Variant__r.Product__c IN (${productIdList})`
     )
   );
-  variantValueList.forEach(value => {
+  variantValueList.forEach((value) => {
     variantValueMap.set(value.Id, value);
   });
   return variantValueMap;
@@ -491,18 +491,18 @@ async function addExportColumns(
   const defaultColumns = new Map([
     ['Product ID', 'Product_ID'],
     ['Title', 'Title'],
-    ['Category Name', 'Category__r.Name'],
+    ['Category Name', 'Category__r.Name']
   ]);
   let exportColumns = [];
   let templateHeaderValueMap = new Map();
 
   // populate default columns first if not templated export
   if (!templateFields || templateFields.length === 0) {
-    Array.from(defaultColumns.keys()).forEach(defaultCol => {
+    Array.from(defaultColumns.keys()).forEach((defaultCol) => {
       exportColumns.push({
         fieldName: defaultColumns.get(defaultCol),
         label: defaultCol,
-        type: 'text',
+        type: 'text'
       });
     });
   }
@@ -513,12 +513,12 @@ async function addExportColumns(
   let linkedGroupsChildren = [];
   let columnAttributeIds = new Set();
   if (linkedAttributes.length > 0) {
-    linkedAttributes.forEach(attr => {
+    linkedAttributes.forEach((attr) => {
       columnAttributeIds.add(attr);
     });
   }
   if (linkedGroups.length > 0) {
-    linkedGroups = linkedGroups.map(id => `'${id}'`).join(',');
+    linkedGroups = linkedGroups.map((id) => `'${id}'`).join(',');
     linkedGroupsChildren = await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Name, Attribute_Group__c
@@ -526,13 +526,13 @@ async function addExportColumns(
         where Attribute_Group__c IN (${linkedGroups})`
       )
     );
-    linkedGroupsChildren.forEach(childAttr => {
+    linkedGroupsChildren.forEach((childAttr) => {
       columnAttributeIds.add(childAttr.Id);
     });
   }
   if (columnAttributeIds.size > 0) {
     columnAttributeIds = Array.from(columnAttributeIds);
-    columnAttributeIds = columnAttributeIds.map(id => `'${id}'`).join(',');
+    columnAttributeIds = columnAttributeIds.map((id) => `'${id}'`).join(',');
 
     // get SOQL query for Label__c of all attribute labels
     const columnAttributes = await service.simpleQuery(
@@ -544,11 +544,11 @@ async function addExportColumns(
     );
 
     // add these attributes as columns to export
-    columnAttributes.forEach(attr => {
+    columnAttributes.forEach((attr) => {
       exportColumns.push({
         fieldName: helper.getValue(attr, 'Primary_Key__c'),
         label: helper.getValue(attr, 'Label__c'),
-        type: 'text',
+        type: 'text'
       });
     });
   } else {
@@ -562,12 +562,12 @@ async function addExportColumns(
     );
 
     if (!templateFields || templateFields.length === 0) {
-      columnAttributes.forEach(attr => {
+      columnAttributes.forEach((attr) => {
         // if not template export, push all attribute columns
         exportColumns.push({
           fieldName: helper.getValue(attr, 'Primary_Key__c'),
           label: helper.getValue(attr, 'Label__c'),
-          type: 'text',
+          type: 'text'
         });
       });
     } else if (templateFields && templateFields.length > 0) {
@@ -586,17 +586,17 @@ async function addExportColumns(
           exportColumns.push({
             fieldName: defaultColumns.get(field),
             label: templateHeaders[i],
-            type: 'text',
+            type: 'text'
           });
         } else if (isAttributeField && !isDefaultColumn) {
           // value specified in template is a field's value, and col in template is an attribute column
           field = field.slice(11, -1);
-          columnAttributes.forEach(colAttr => {
+          columnAttributes.forEach((colAttr) => {
             if (helper.getValue(colAttr, 'Label__c') === field) {
               exportColumns.push({
                 fieldName: helper.getValue(colAttr, 'Primary_Key__c'),
                 label: templateHeaders[i],
-                type: 'text',
+                type: 'text'
               });
             }
           });
@@ -606,15 +606,15 @@ async function addExportColumns(
           exportColumns.push({
             fieldName: templateHeaders[i],
             label: templateHeaders[i],
-            type: 'text',
+            type: 'text'
           });
         }
       }
     }
   }
   // populate export records with raw values specified in the template
-  Array.from(templateHeaderValueMap.keys()).forEach(header => {
-    exportRecordsAndColumns[0].forEach(recordMap => {
+  Array.from(templateHeaderValueMap.keys()).forEach((header) => {
+    exportRecordsAndColumns[0].forEach((recordMap) => {
       recordMap.set(header, templateHeaderValueMap.get(header));
     });
   });

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -27,7 +27,6 @@ async function PimStructure(reqBody, isListPageExport) {
     // export is from product data page
     /** PIM repo ProductService.getProductById start */
     // PIM repo ProductManager.buildWithProductIds
-    console.log('reqbodyu: ', reqBody);
     let productsList = await PimProductManager(recordIds, helper, service);
 
     // PIM repo ProductService.getResultForProductStructure(productsList)
@@ -317,6 +316,9 @@ async function PimStructure(reqBody, isListPageExport) {
       const templateRows = reqBody.templateVersionData.split('\n');
       templateHeaders = templateRows[0].split(',');
       templateFields = templateRows[1].split(',');
+      console.log('templateRows: ', templateRows);
+      console.log('templateHeaders: ', templateHeaders);
+      console.log('templateFields: ', templateFields);
       for (let i = 0; i < templateFields.length; i++) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -322,8 +322,10 @@ async function PimStructure(reqBody, isListPageExport) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
           templateFields[i] = templateFields[i].split('"');
+          console.log('Math.floor(templateFields[i].length / 2): ', Math.floor(templateFields[i].length / 2));
           templateFields[i] =
             templateFields[i][Math.floor(templateFields[i].length / 2)];
+          console.log('templateFields[i]: ', templateFields[i]);
           if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
             templateFields[i] = templateFields[i].slice(11, -1);
           }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -321,8 +321,8 @@ async function PimStructure(reqBody, isListPageExport) {
       for (let i = 0; i < templateFields.length; i++) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
-          templateFields[i] = templateFields[i].split('"');
-          console.log('Math.floor(templateFields[i].length / 2): ', Math.floor(templateFields[i].length / 2));
+          templateFields[i] = templateFields[i].split('\"');
+          console.log('templateFields[i].length: ', templateFields[i].length);
           templateFields[i] =
             templateFields[i][Math.floor(templateFields[i].length / 2)];
           console.log('templateFields[i]: ', templateFields[i]);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -636,13 +636,16 @@ async function addExportColumns(
     for (let i = 0; i < templateFields.length; i++) {
       field = templateFields[i];
       if (field.includes(ATTRIBUTE_FLAG)) {
+        console.log('field includes flag: ', field);
         // template specifies that the column's rows should contain a field's value
         field = field.slice(11, -1);
+        console.log('field after slice: ', field);
         Array.from(productVariantValueMapList[0].keys()).forEach(col => {
           const isMatchingColAndField =
             (field !== 'Product ID' && field === col) ||
             (col === 'Product_ID' && field === 'Product ID');
           if (col !== 'Id' && isMatchingColAndField) {
+            console.log('cols pushed');
             // push columns specified in template
             exportColumns = [
               ...exportColumns,
@@ -653,6 +656,7 @@ async function addExportColumns(
               },
             ];
           }
+          console.log('exportColumns: ', exportColumns);
         });
       } else {
         // template specifies that the column's rows should contain the raw value in the template

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -313,7 +313,7 @@ async function PimStructure(reqBody, isListPageExport) {
     let templateHeaders;
     if (reqBody.options.isTemplateExport && reqBody.templateVersionData) {
       // parse headers and fields and store them in a map
-      const templateRows = reqBody.templateVersionData.split('\n');
+      const templateRows = reqBody.templateVersionData.split(/\r?\n/);
       templateHeaders = templateRows[0].split(',');
       templateFields = templateRows[1].split(',');
       console.log('templateRows: ', templateRows);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -316,9 +316,8 @@ async function PimStructure(reqBody, isListPageExport) {
       const templateRows = reqBody.templateVersionData.split(/\r?\n/);
       templateHeaders = templateRows[0].split(',');
       templateFields = templateRows[1].split(',');
-      console.log('templateRows: ', templateRows);
-      console.log('templateHeaders: ', templateHeaders);
-      console.log('templateFields: ', templateFields);
+      console.log('templateHeaders1: ', templateHeaders);
+      console.log('templateFields1: ', templateFields);
       for (let i = 0; i < templateFields.length; i++) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
@@ -332,6 +331,8 @@ async function PimStructure(reqBody, isListPageExport) {
         }
       }
     }
+    console.log('templateHeaders2: ', templateHeaders);
+    console.log('templateFields2: ', templateFields);
     return await addExportColumns(
       productVariantValueMapList,
       templateFields,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -13,7 +13,7 @@ async function PimStructure(reqBody, isListPageExport) {
   service = new ForceService(reqBody.hostUrl, reqBody.sessionId);
 
   let exportRecordsAndCols = [];
-  const recordIds = reqBody.recordIds.map((id) => `'${id}'`).join(',');
+  const recordIds = reqBody.recordIds.map(id => `'${id}'`).join(',');
   const exportType = reqBody.exportType;
   const namespace = reqBody.namespace;
   helper = new PimExportHelper(namespace);
@@ -43,7 +43,7 @@ async function PimStructure(reqBody, isListPageExport) {
     const excludedLabelIds = reqBody.excludedLabelIds;
     let linkedLabelIds = [];
     const linkedGroupIds = reqBody.linkedGroupIds
-      .map((id) => `'${id}'`)
+      .map(id => `'${id}'`)
       .join(',');
     const linkedGroups = await service.simpleQuery(
       helper.namespaceQuery(
@@ -69,11 +69,11 @@ async function PimStructure(reqBody, isListPageExport) {
       )
     );
     // add child attributes of linked attribute groups (following logic of PIM repo's ProductDetailController.generateLayout())
-    linkedGroups.forEach((attrGroup) => {
+    linkedGroups.forEach(attrGroup => {
       if (helper.getValue(attrGroup, 'Attribute_Labels__r')) {
         helper
           .getValue(attrGroup, 'Attribute_Labels__r')
-          .records.forEach((attrLabel) => {
+          .records.forEach(attrLabel => {
             if (!excludedLabelIds.includes(attrLabel.Id)) {
               linkedLabelIds.push(attrLabel.Id);
             }
@@ -81,7 +81,7 @@ async function PimStructure(reqBody, isListPageExport) {
       }
     });
     // add linked attribute labels and their values to base product
-    linkedLabelIds = linkedLabelIds.map((id) => `'${id}'`).join(',');
+    linkedLabelIds = linkedLabelIds.map(id => `'${id}'`).join(',');
     const linkedLabels = await service.simpleQuery(
       helper.namespaceQuery(`select Id, Name
       from Attribute_Label__c
@@ -101,9 +101,9 @@ async function PimStructure(reqBody, isListPageExport) {
           Overwritten_Variant_Value__c = null)`
       )
     );
-    linkedLabels.forEach((label) => {
+    linkedLabels.forEach(label => {
       // add the base product's attribute values
-      linkedValues.forEach((val) => {
+      linkedValues.forEach(val => {
         if (
           helper.getValue(val, 'Attribute_Label__c') === label.Id &&
           helper.getValue(val, 'Product__c') === exportRecords[0].get('Id')
@@ -122,7 +122,7 @@ async function PimStructure(reqBody, isListPageExport) {
 
     if (exportType === 'currentVariant') {
       let variantValuePath = reqBody.variantValuePath
-        .map((id) => `'${id}'`)
+        .map(id => `'${id}'`)
         .join(',');
       if (variantValuePath.length > 0) {
         // get Variant__c object and Variant_Value__c object for every variant value in current variant
@@ -136,10 +136,10 @@ async function PimStructure(reqBody, isListPageExport) {
         const varList = Array.from(variantAndValueMap.keys());
         valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
         let valuesIdList = [];
-        valuesList.forEach((val) => {
+        valuesList.forEach(val => {
           valuesIdList.push(val[0].Id);
         });
-        valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
+        valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
         const overwrittenValues = await service.simpleQuery(
           helper.namespaceQuery(
             `select Id, Attribute_Label__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -162,9 +162,9 @@ async function PimStructure(reqBody, isListPageExport) {
 
           // add any overwritten values
           if (overwrittenValues.length > 0) {
-            overwrittenValues.forEach((overwrittenValue) => {
+            overwrittenValues.forEach(overwrittenValue => {
               let affectedLabelName;
-              linkedLabels.forEach((label) => {
+              linkedLabels.forEach(label => {
                 if (
                   label.Id ===
                   helper.getValue(overwrittenValue, 'Attribute_Label__c')
@@ -208,14 +208,14 @@ async function PimStructure(reqBody, isListPageExport) {
       let newVariant = new Map();
       let varList = Array.from(variantAndValueListMap.keys());
       valuesList = [];
-      Array.from(variantAndValueListMap.values()).forEach((valList) => {
+      Array.from(variantAndValueListMap.values()).forEach(valList => {
         valuesList.push.apply(valuesList, valList); // flatten array
       });
       let valuesIdList = [];
-      valuesList.forEach((val) => {
+      valuesList.forEach(val => {
         valuesIdList.push(val.Id);
       });
-      valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
+      valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
       const overwrittenValues = await service.simpleQuery(
         helper.namespaceQuery(
           `select Id, Attribute_Label__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -230,7 +230,7 @@ async function PimStructure(reqBody, isListPageExport) {
 
       let currValue;
       let isFirstLevelVariant;
-      valuesList.forEach((val) => {
+      valuesList.forEach(val => {
         newVariant = new Map();
         currValue = val;
         isFirstLevelVariant = true;
@@ -267,9 +267,9 @@ async function PimStructure(reqBody, isListPageExport) {
 
         // add any overwritten values
         if (overwrittenValues.length > 0) {
-          overwrittenValues.forEach((overwrittenValue) => {
+          overwrittenValues.forEach(overwrittenValue => {
             let affectedLabelName;
-            linkedLabels.forEach((label) => {
+            linkedLabels.forEach(label => {
               if (
                 label.Id ===
                 helper.getValue(overwrittenValue, 'Attribute_Label__c')
@@ -335,12 +335,12 @@ async function PimStructure(reqBody, isListPageExport) {
 // PIM repo ProductService.getVariantAndVariantValues
 async function getVariantAndVariantValues(variantValueIds, exportType) {
   let valueIds = [];
-  variantValueIds.split(', ').forEach((id) => {
+  variantValueIds.split(', ').forEach(id => {
     valueIds.push(id);
   });
   valueIds =
     exportType === 'allVariants'
-      ? valueIds.map((id) => `'${id}'`).join(',')
+      ? valueIds.map(id => `'${id}'`).join(',')
       : valueIds;
   let returnMap = new Map();
   let values = await service.simpleQuery(
@@ -358,7 +358,7 @@ async function getVariantAndVariantValues(variantValueIds, exportType) {
   );
 
   let tempVariant;
-  values.forEach((value) => {
+  values.forEach(value => {
     tempVariant = {
       Id: helper.getValue(value, 'Variant__c'),
       Name: helper.getValue(value, 'Variant__r').Name
@@ -403,14 +403,14 @@ async function fillInInheritedData(
     let newVariant = new Map();
     let varList = Array.from(variantAndValueListMap.keys());
     valuesList = [];
-    Array.from(variantAndValueListMap.values()).forEach((valList) => {
+    Array.from(variantAndValueListMap.values()).forEach(valList => {
       valuesList.push.apply(valuesList, valList); // flatten array
     });
     let valuesIdList = [];
-    valuesList.forEach((val) => {
+    valuesList.forEach(val => {
       valuesIdList.push(val.Id);
     });
-    valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
+    valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
     const overwrittenValues = await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Attribute_Label__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -425,7 +425,7 @@ async function fillInInheritedData(
 
     let currValue;
     let isFirstLevelVariant;
-    valuesList.forEach((val) => {
+    valuesList.forEach(val => {
       newVariant = new Map();
       currValue = val;
       isFirstLevelVariant = true;
@@ -462,9 +462,9 @@ async function fillInInheritedData(
 
       // add any overwritten values
       if (overwrittenValues.length > 0) {
-        overwrittenValues.forEach((overwrittenValue) => {
+        overwrittenValues.forEach(overwrittenValue => {
           let affectedLabelName;
-          linkedLabels.forEach((label) => {
+          linkedLabels.forEach(label => {
             if (
               label.Id ===
               helper.getValue(overwrittenValue, 'Attribute_Label__c')
@@ -494,7 +494,7 @@ async function fillInInheritedData(
 
   // loop through base product's data
   let baseProductData = new Map();
-  Array.from(baseProduct.keys()).forEach((key) => {
+  Array.from(baseProduct.keys()).forEach(key => {
     if (baseProduct.get(key) != null && baseProduct.get(key) != '') {
       // baseProduct has value for that attribute
       baseProductData.set(key, baseProduct.get(key));
@@ -504,10 +504,10 @@ async function fillInInheritedData(
   // loop through baseProduct's children to settle inheritance from base product
   variantValueTree
     .get(baseProduct.get('Product_ID'))
-    .forEach((firstLevelVariant) => {
-      exportRecords.forEach((variant) => {
+    .forEach(firstLevelVariant => {
+      exportRecords.forEach(variant => {
         if (variant.get('Product_ID') === firstLevelVariant) {
-          Array.from(baseProductData.keys()).forEach((key) => {
+          Array.from(baseProductData.keys()).forEach(key => {
             if (
               !variant.has(key) ||
               (variant.has(key) &&
@@ -529,11 +529,11 @@ async function fillInInheritedData(
     });
 
   // loop through each variant (top down) to settle inheritance from parent variants
-  exportRecords.forEach((variant) => {
-    variantValueTree.get(variant.get('Product_ID')).forEach((childVariant) => {
-      exportRecords.forEach((variantValue) => {
+  exportRecords.forEach(variant => {
+    variantValueTree.get(variant.get('Product_ID')).forEach(childVariant => {
+      exportRecords.forEach(variantValue => {
         if (variantValue.get('Product_ID') === childVariant) {
-          Array.from(variant.keys()).forEach((key) => {
+          Array.from(variant.keys()).forEach(key => {
             if (
               !variantValue.has(key) ||
               (variantValue.has(key) &&
@@ -570,7 +570,7 @@ async function createVariantValueTree(valuesList, baseProduct) {
   variantValueTree.push(treeNode);
 
   // add nodes for variants
-  valuesList.forEach((value) => {
+  valuesList.forEach(value => {
     treeNode = new Map();
     treeNode.set('Product_ID', value.Name);
     treeNode.set('Id', value.Id);
@@ -578,7 +578,7 @@ async function createVariantValueTree(valuesList, baseProduct) {
     if (helper.getValue(value, 'Parent_Variant_Value__c')) {
       const parentId = helper.getValue(value, 'Parent_Variant_Value__c');
       // add current variant value's id to the list of children in its parent in variantValueTree
-      variantValueTree.forEach((node) => {
+      variantValueTree.forEach(node => {
         if (node.get('Id') === parentId) {
           let childrenList = node.get('Children');
           childrenList.push(value.Name);
@@ -596,7 +596,7 @@ async function createVariantValueTree(valuesList, baseProduct) {
 
   // convert the data structure to reduce search overhead
   let childMap = new Map();
-  variantValueTree.forEach((variant) => {
+  variantValueTree.forEach(variant => {
     childMap.set(variant.get('Product_ID'), variant.get('Children'));
   });
   return childMap;
@@ -612,7 +612,7 @@ async function addExportColumns(
   let templateHeaderValueMap = new Map();
   if (!templateFields || templateFields.length === 0) {
     // if not template export, push all attribute columns
-    Array.from(productVariantValueMapList[0].keys()).forEach((col) => {
+    Array.from(productVariantValueMapList[0].keys()).forEach(col => {
       if (col !== 'Id') {
         exportColumns = [
           ...exportColumns,
@@ -628,7 +628,7 @@ async function addExportColumns(
       if (field.includes(ATTRIBUTE_FLAG)) {
         // template specifies that the column's rows should contain a field's value
         field = field.slice(11, -1);
-        Array.from(productVariantValueMapList[0].keys()).forEach((col) => {
+        Array.from(productVariantValueMapList[0].keys()).forEach(col => {
           const isMatchingColAndField =
             (field !== 'Product ID' && field === col) ||
             (col === 'Product_ID' && field === 'Product ID');
@@ -658,8 +658,8 @@ async function addExportColumns(
       }
     }
     // populate export records with raw values specified in the template
-    Array.from(templateHeaderValueMap.keys()).forEach((header) => {
-      exportRecordsAndCols[0].forEach((recordMap) => {
+    Array.from(templateHeaderValueMap.keys()).forEach(header => {
+      exportRecordsAndCols[0].forEach(recordMap => {
         recordMap.set(header, templateHeaderValueMap.get(header));
       });
     });

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -13,7 +13,7 @@ async function PimStructure(reqBody, isListPageExport) {
   service = new ForceService(reqBody.hostUrl, reqBody.sessionId);
 
   let exportRecordsAndCols = [];
-  const recordIds = reqBody.recordIds.map(id => `'${id}'`).join(',');
+  const recordIds = reqBody.recordIds.map((id) => `'${id}'`).join(',');
   const exportType = reqBody.exportType;
   const namespace = reqBody.namespace;
   helper = new PimExportHelper(namespace);
@@ -43,7 +43,7 @@ async function PimStructure(reqBody, isListPageExport) {
     const excludedLabelIds = reqBody.excludedLabelIds;
     let linkedLabelIds = [];
     const linkedGroupIds = reqBody.linkedGroupIds
-      .map(id => `'${id}'`)
+      .map((id) => `'${id}'`)
       .join(',');
     const linkedGroups = await service.simpleQuery(
       helper.namespaceQuery(
@@ -69,11 +69,11 @@ async function PimStructure(reqBody, isListPageExport) {
       )
     );
     // add child attributes of linked attribute groups (following logic of PIM repo's ProductDetailController.generateLayout())
-    linkedGroups.forEach(attrGroup => {
+    linkedGroups.forEach((attrGroup) => {
       if (helper.getValue(attrGroup, 'Attribute_Labels__r')) {
         helper
           .getValue(attrGroup, 'Attribute_Labels__r')
-          .records.forEach(attrLabel => {
+          .records.forEach((attrLabel) => {
             if (!excludedLabelIds.includes(attrLabel.Id)) {
               linkedLabelIds.push(attrLabel.Id);
             }
@@ -81,7 +81,7 @@ async function PimStructure(reqBody, isListPageExport) {
       }
     });
     // add linked attribute labels and their values to base product
-    linkedLabelIds = linkedLabelIds.map(id => `'${id}'`).join(',');
+    linkedLabelIds = linkedLabelIds.map((id) => `'${id}'`).join(',');
     const linkedLabels = await service.simpleQuery(
       helper.namespaceQuery(`select Id, Name
       from Attribute_Label__c
@@ -101,9 +101,9 @@ async function PimStructure(reqBody, isListPageExport) {
           Overwritten_Variant_Value__c = null)`
       )
     );
-    linkedLabels.forEach(label => {
+    linkedLabels.forEach((label) => {
       // add the base product's attribute values
-      linkedValues.forEach(val => {
+      linkedValues.forEach((val) => {
         if (
           helper.getValue(val, 'Attribute_Label__c') === label.Id &&
           helper.getValue(val, 'Product__c') === exportRecords[0].get('Id')
@@ -122,7 +122,7 @@ async function PimStructure(reqBody, isListPageExport) {
 
     if (exportType === 'currentVariant') {
       let variantValuePath = reqBody.variantValuePath
-        .map(id => `'${id}'`)
+        .map((id) => `'${id}'`)
         .join(',');
       if (variantValuePath.length > 0) {
         // get Variant__c object and Variant_Value__c object for every variant value in current variant
@@ -136,10 +136,10 @@ async function PimStructure(reqBody, isListPageExport) {
         const varList = Array.from(variantAndValueMap.keys());
         valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
         let valuesIdList = [];
-        valuesList.forEach(val => {
+        valuesList.forEach((val) => {
           valuesIdList.push(val[0].Id);
         });
-        valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
+        valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
         const overwrittenValues = await service.simpleQuery(
           helper.namespaceQuery(
             `select Id, Attribute_Label__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -162,9 +162,9 @@ async function PimStructure(reqBody, isListPageExport) {
 
           // add any overwritten values
           if (overwrittenValues.length > 0) {
-            overwrittenValues.forEach(overwrittenValue => {
+            overwrittenValues.forEach((overwrittenValue) => {
               let affectedLabelName;
-              linkedLabels.forEach(label => {
+              linkedLabels.forEach((label) => {
                 if (
                   label.Id ===
                   helper.getValue(overwrittenValue, 'Attribute_Label__c')
@@ -208,14 +208,14 @@ async function PimStructure(reqBody, isListPageExport) {
       let newVariant = new Map();
       let varList = Array.from(variantAndValueListMap.keys());
       valuesList = [];
-      Array.from(variantAndValueListMap.values()).forEach(valList => {
+      Array.from(variantAndValueListMap.values()).forEach((valList) => {
         valuesList.push.apply(valuesList, valList); // flatten array
       });
       let valuesIdList = [];
-      valuesList.forEach(val => {
+      valuesList.forEach((val) => {
         valuesIdList.push(val.Id);
       });
-      valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
+      valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
       const overwrittenValues = await service.simpleQuery(
         helper.namespaceQuery(
           `select Id, Attribute_Label__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -230,7 +230,7 @@ async function PimStructure(reqBody, isListPageExport) {
 
       let currValue;
       let isFirstLevelVariant;
-      valuesList.forEach(val => {
+      valuesList.forEach((val) => {
         newVariant = new Map();
         currValue = val;
         isFirstLevelVariant = true;
@@ -267,9 +267,9 @@ async function PimStructure(reqBody, isListPageExport) {
 
         // add any overwritten values
         if (overwrittenValues.length > 0) {
-          overwrittenValues.forEach(overwrittenValue => {
+          overwrittenValues.forEach((overwrittenValue) => {
             let affectedLabelName;
-            linkedLabels.forEach(label => {
+            linkedLabels.forEach((label) => {
               if (
                 label.Id ===
                 helper.getValue(overwrittenValue, 'Attribute_Label__c')
@@ -316,26 +316,13 @@ async function PimStructure(reqBody, isListPageExport) {
       const templateRows = reqBody.templateVersionData.split(/\r?\n/);
       templateHeaders = templateRows[0].split(',');
       templateFields = templateRows[1].split(',');
-      console.log('templateHeaders1: ', templateHeaders);
-      console.log('templateFields1: ', templateFields);
       for (let i = 0; i < templateFields.length; i++) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
-          // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
-          console.log('templateFields[i]: ', templateFields[i]);
-          templateFields[i] = templateFields[i].split("\"");
-          console.log('templateFields[i]: ', templateFields[i]);
-          templateFields[i] =
-            templateFields[i][Math.floor(templateFields[i].length / 2)];
-          console.log('templateFields[i]: ', templateFields[i]);
-          if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
-            templateFields[i] = templateFields[i].slice(11, -1);
-          }
-          templateFields[i] = 'PROPEL_ATT(' + templateFields[i] + ')';
+          // remove double quotes (note the 3 different kinds of double quotes in the regex)
+          templateFields[i] = templateFields[i].replace(/["“”]+/g, '');
         }
       }
     }
-    console.log('templateHeaders2: ', templateHeaders);
-    console.log('templateFields2: ', templateFields);
     return await addExportColumns(
       productVariantValueMapList,
       templateFields,
@@ -348,12 +335,12 @@ async function PimStructure(reqBody, isListPageExport) {
 // PIM repo ProductService.getVariantAndVariantValues
 async function getVariantAndVariantValues(variantValueIds, exportType) {
   let valueIds = [];
-  variantValueIds.split(', ').forEach(id => {
+  variantValueIds.split(', ').forEach((id) => {
     valueIds.push(id);
   });
   valueIds =
     exportType === 'allVariants'
-      ? valueIds.map(id => `'${id}'`).join(',')
+      ? valueIds.map((id) => `'${id}'`).join(',')
       : valueIds;
   let returnMap = new Map();
   let values = await service.simpleQuery(
@@ -371,10 +358,10 @@ async function getVariantAndVariantValues(variantValueIds, exportType) {
   );
 
   let tempVariant;
-  values.forEach(value => {
+  values.forEach((value) => {
     tempVariant = {
       Id: helper.getValue(value, 'Variant__c'),
-      Name: helper.getValue(value, 'Variant__r').Name,
+      Name: helper.getValue(value, 'Variant__r').Name
     };
     if (returnMap.has(tempVariant)) {
       returnMap.set(tempVariant, [...returnMap.get(tempVariant), value]);
@@ -416,14 +403,14 @@ async function fillInInheritedData(
     let newVariant = new Map();
     let varList = Array.from(variantAndValueListMap.keys());
     valuesList = [];
-    Array.from(variantAndValueListMap.values()).forEach(valList => {
+    Array.from(variantAndValueListMap.values()).forEach((valList) => {
       valuesList.push.apply(valuesList, valList); // flatten array
     });
     let valuesIdList = [];
-    valuesList.forEach(val => {
+    valuesList.forEach((val) => {
       valuesIdList.push(val.Id);
     });
-    valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
+    valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
     const overwrittenValues = await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Attribute_Label__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -438,7 +425,7 @@ async function fillInInheritedData(
 
     let currValue;
     let isFirstLevelVariant;
-    valuesList.forEach(val => {
+    valuesList.forEach((val) => {
       newVariant = new Map();
       currValue = val;
       isFirstLevelVariant = true;
@@ -475,9 +462,9 @@ async function fillInInheritedData(
 
       // add any overwritten values
       if (overwrittenValues.length > 0) {
-        overwrittenValues.forEach(overwrittenValue => {
+        overwrittenValues.forEach((overwrittenValue) => {
           let affectedLabelName;
-          linkedLabels.forEach(label => {
+          linkedLabels.forEach((label) => {
             if (
               label.Id ===
               helper.getValue(overwrittenValue, 'Attribute_Label__c')
@@ -507,7 +494,7 @@ async function fillInInheritedData(
 
   // loop through base product's data
   let baseProductData = new Map();
-  Array.from(baseProduct.keys()).forEach(key => {
+  Array.from(baseProduct.keys()).forEach((key) => {
     if (baseProduct.get(key) != null && baseProduct.get(key) != '') {
       // baseProduct has value for that attribute
       baseProductData.set(key, baseProduct.get(key));
@@ -517,10 +504,10 @@ async function fillInInheritedData(
   // loop through baseProduct's children to settle inheritance from base product
   variantValueTree
     .get(baseProduct.get('Product_ID'))
-    .forEach(firstLevelVariant => {
-      exportRecords.forEach(variant => {
+    .forEach((firstLevelVariant) => {
+      exportRecords.forEach((variant) => {
         if (variant.get('Product_ID') === firstLevelVariant) {
-          Array.from(baseProductData.keys()).forEach(key => {
+          Array.from(baseProductData.keys()).forEach((key) => {
             if (
               !variant.has(key) ||
               (variant.has(key) &&
@@ -542,11 +529,11 @@ async function fillInInheritedData(
     });
 
   // loop through each variant (top down) to settle inheritance from parent variants
-  exportRecords.forEach(variant => {
-    variantValueTree.get(variant.get('Product_ID')).forEach(childVariant => {
-      exportRecords.forEach(variantValue => {
+  exportRecords.forEach((variant) => {
+    variantValueTree.get(variant.get('Product_ID')).forEach((childVariant) => {
+      exportRecords.forEach((variantValue) => {
         if (variantValue.get('Product_ID') === childVariant) {
-          Array.from(variant.keys()).forEach(key => {
+          Array.from(variant.keys()).forEach((key) => {
             if (
               !variantValue.has(key) ||
               (variantValue.has(key) &&
@@ -583,7 +570,7 @@ async function createVariantValueTree(valuesList, baseProduct) {
   variantValueTree.push(treeNode);
 
   // add nodes for variants
-  valuesList.forEach(value => {
+  valuesList.forEach((value) => {
     treeNode = new Map();
     treeNode.set('Product_ID', value.Name);
     treeNode.set('Id', value.Id);
@@ -591,7 +578,7 @@ async function createVariantValueTree(valuesList, baseProduct) {
     if (helper.getValue(value, 'Parent_Variant_Value__c')) {
       const parentId = helper.getValue(value, 'Parent_Variant_Value__c');
       // add current variant value's id to the list of children in its parent in variantValueTree
-      variantValueTree.forEach(node => {
+      variantValueTree.forEach((node) => {
         if (node.get('Id') === parentId) {
           let childrenList = node.get('Children');
           childrenList.push(value.Name);
@@ -609,7 +596,7 @@ async function createVariantValueTree(valuesList, baseProduct) {
 
   // convert the data structure to reduce search overhead
   let childMap = new Map();
-  variantValueTree.forEach(variant => {
+  variantValueTree.forEach((variant) => {
     childMap.set(variant.get('Product_ID'), variant.get('Children'));
   });
   return childMap;
@@ -625,11 +612,11 @@ async function addExportColumns(
   let templateHeaderValueMap = new Map();
   if (!templateFields || templateFields.length === 0) {
     // if not template export, push all attribute columns
-    Array.from(productVariantValueMapList[0].keys()).forEach(col => {
+    Array.from(productVariantValueMapList[0].keys()).forEach((col) => {
       if (col !== 'Id') {
         exportColumns = [
           ...exportColumns,
-          { fieldName: col, label: col, type: 'text' },
+          { fieldName: col, label: col, type: 'text' }
         ];
       }
     });
@@ -641,7 +628,7 @@ async function addExportColumns(
       if (field.includes(ATTRIBUTE_FLAG)) {
         // template specifies that the column's rows should contain a field's value
         field = field.slice(11, -1);
-        Array.from(productVariantValueMapList[0].keys()).forEach(col => {
+        Array.from(productVariantValueMapList[0].keys()).forEach((col) => {
           const isMatchingColAndField =
             (field !== 'Product ID' && field === col) ||
             (col === 'Product_ID' && field === 'Product ID');
@@ -652,8 +639,8 @@ async function addExportColumns(
               {
                 fieldName: col,
                 label: templateHeaders[i],
-                type: 'text',
-              },
+                type: 'text'
+              }
             ];
           }
         });
@@ -665,14 +652,14 @@ async function addExportColumns(
           {
             fieldName: templateHeaders[i],
             label: templateHeaders[i],
-            type: 'text',
-          },
+            type: 'text'
+          }
         ];
       }
     }
     // populate export records with raw values specified in the template
-    Array.from(templateHeaderValueMap.keys()).forEach(header => {
-      exportRecordsAndCols[0].forEach(recordMap => {
+    Array.from(templateHeaderValueMap.keys()).forEach((header) => {
+      exportRecordsAndCols[0].forEach((recordMap) => {
         recordMap.set(header, templateHeaderValueMap.get(header));
       });
     });

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -322,7 +322,7 @@ async function PimStructure(reqBody, isListPageExport) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
           console.log('templateFields[i]: ', templateFields[i]);
-          templateFields[i] = templateFields[i].split('\"');
+          templateFields[i] = templateFields[i].split("\"");
           console.log('templateFields[i]: ', templateFields[i]);
           templateFields[i] =
             templateFields[i][Math.floor(templateFields[i].length / 2)];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -321,6 +321,7 @@ async function PimStructure(reqBody, isListPageExport) {
       for (let i = 0; i < templateFields.length; i++) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
+          console.log('templateFields[i]: ', templateFields[i]);
           templateFields[i] = templateFields[i].split('\"');
           console.log('templateFields[i]: ', templateFields[i]);
           templateFields[i] =
@@ -638,16 +639,13 @@ async function addExportColumns(
     for (let i = 0; i < templateFields.length; i++) {
       field = templateFields[i];
       if (field.includes(ATTRIBUTE_FLAG)) {
-        console.log('field includes flag: ', field);
         // template specifies that the column's rows should contain a field's value
         field = field.slice(11, -1);
-        console.log('field after slice: ', field);
         Array.from(productVariantValueMapList[0].keys()).forEach(col => {
           const isMatchingColAndField =
             (field !== 'Product ID' && field === col) ||
             (col === 'Product_ID' && field === 'Product ID');
           if (col !== 'Id' && isMatchingColAndField) {
-            console.log('cols pushed');
             // push columns specified in template
             exportColumns = [
               ...exportColumns,
@@ -658,7 +656,6 @@ async function addExportColumns(
               },
             ];
           }
-          console.log('exportColumns: ', exportColumns);
         });
       } else {
         // template specifies that the column's rows should contain the raw value in the template

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -322,7 +322,7 @@ async function PimStructure(reqBody, isListPageExport) {
         if (templateFields[i].includes(ATTRIBUTE_FLAG)) {
           // remove PROPEL_ATT() flag temporarily to remove double quotes or consecutive double quotes
           templateFields[i] = templateFields[i].split('\"');
-          console.log('templateFields[i].length: ', templateFields[i].length);
+          console.log('templateFields[i]: ', templateFields[i]);
           templateFields[i] =
             templateFields[i][Math.floor(templateFields[i].length / 2)];
           console.log('templateFields[i]: ', templateFields[i]);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -27,6 +27,7 @@ async function PimStructure(reqBody, isListPageExport) {
     // export is from product data page
     /** PIM repo ProductService.getProductById start */
     // PIM repo ProductManager.buildWithProductIds
+    console.log('reqbodyu: ', reqBody);
     let productsList = await PimProductManager(recordIds, helper, service);
 
     // PIM repo ProductService.getResultForProductStructure(productsList)


### PR DESCRIPTION
Fix the bug that prevented template export from working.

https://user-images.githubusercontent.com/77341283/198339000-ad620734-f7ee-44c2-80ca-ba0c26a0e872.mov

Apart from all the automatic style changes from Prettier, the main changes for the bug fix are at 
- PimProductListHelper.js line 123, 124
- PimStructure.js line 321, 322

The root cause of the problem is the discrepancy between 3 different types of double quotes, which are now fully accounted for in the regex in lines 124 and 322 mentioned above. Previously this was not an issue as perhaps Salesforce ContentVersion converted all 3 types of double quotes (ASCII Codes 34, 8220, and 8221) to ASCII Code 34 (just a guess).