### PR TITLE
PIM-442: Digital Asset List page | Binary Export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# quick test files
+quickTest.js
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -8,5 +8,6 @@
     ],
     "tabWidth": 4,
     "useTabs": false,
-    "singleQuote": true
+    "singleQuote": true,
+    "arrowParens": "avoid"
 }

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -20,7 +20,7 @@ async function LegacyExportPIM(req) {
   }
 
   const baseFileName = createBaseFileName();
-  const filename = 'Product-Export_' + baseFileName + '.csv';
+  const filename = `Product-Export_${baseFileName}.csv`;
 
   sendDADownloadRequests(baseFileName, daDownloadDetailsList, reqBody.sessionId, reqBody.hostUrl);
 
@@ -125,11 +125,11 @@ function createBaseFileName() {
 
 async function sendDADownloadRequests(zipFileName, daDownloadDetailsList, sessionId, hostName) {
   if (!daDownloadDetailsList || !daDownloadDetailsList.length) return;
-  zipFileName = 'Digital_Asset-Export_' + zipFileName + '.zip';
+  zipFileName = `Digital_Asset-Export_${zipFileName}.zip`;
 
-  const payload = JSON.stringify({ 
-    platform: 'aws', 
-    zipFileName, 
+  const payload = JSON.stringify({
+    platform: 'aws',
+    zipFileName,
     daDownloadDetailsList,
     hostName,
     sessionId,

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var crypto = require('crypto');
+const https = require('https');
 
 const PimStructure = require('./PimStructure');
 const { postToChatter } = require('./utils');
@@ -11,12 +12,18 @@ async function LegacyExportPIM(req) {
   if (reqBody.recordIds.length == 0) {
     return 'Error';
   }
-  let recordsAndCols;
+  let daDownloadDetailsList, recordsAndCols;
   try {
-    recordsAndCols = await PimStructure(reqBody, isListPageExport);
+    ({daDownloadDetailsList, recordsAndCols} = await PimStructure(reqBody, isListPageExport));
   } catch (err) {
     console.log('error: ', err);
   }
+
+  const baseFileName = createBaseFileName();
+  const filename = 'Product-Export_' + baseFileName + '.csv';
+
+  sendDADownloadRequests(baseFileName, daDownloadDetailsList, reqBody.sessionId, reqBody.hostUrl);
+
   let csvString = convertArrayOfObjectsToCSV(
     recordsAndCols[0],
     recordsAndCols[1]
@@ -25,27 +32,6 @@ async function LegacyExportPIM(req) {
     return 'Error';
   }
 
-  // Create empty csv file
-  let date = new Date();
-  const year = date.getFullYear();
-  const month = ('0' + (date.getMonth() + 1)).slice(-2);
-  const day = ('0' + date.getDate()).slice(-2);
-  const hour = ('0' + date.getHours()).slice(-2);
-  const minutes = ('0' + date.getMinutes()).slice(-2);
-  const seconds = ('0' + date.getSeconds()).slice(-2);
-
-  const filename =
-    'Product-Export_' +
-    year +
-    '-' +
-    month +
-    '-' +
-    day +
-    '_' +
-    hour +
-    minutes +
-    seconds +
-    '.csv';
   const nameOnDisk = crypto.randomBytes(20).toString('hex') + filename;
   const file = fs.createWriteStream(nameOnDisk);
   reqBody.shouldPostToUser = true;
@@ -115,6 +101,55 @@ function convertArrayOfObjectsToCSV(records, columns) {
     csvStringResult += lineDivider;
   }
   return csvStringResult;
+}
+
+function createBaseFileName() {
+  let date = new Date();
+  const year = date.getFullYear();
+  const month = ('0' + (date.getMonth() + 1)).slice(-2);
+  const day = ('0' + date.getDate()).slice(-2);
+  const hour = ('0' + date.getHours()).slice(-2);
+  const minutes = ('0' + date.getMinutes()).slice(-2);
+  const seconds = ('0' + date.getSeconds()).slice(-2);
+
+  return year +
+    '-' +
+    month +
+    '-' +
+    day +
+    '_' +
+    hour +
+    minutes +
+    seconds;
+}
+
+async function sendDADownloadRequests(zipFileName, daDownloadDetailsList, sessionId, hostName) {
+  if (!daDownloadDetailsList || !daDownloadDetailsList.length) return;
+  zipFileName = 'Digital_Asset-Export_' + zipFileName + '.zip';
+
+  const payload = JSON.stringify({ 
+    platform: 'aws', 
+    zipFileName, 
+    daDownloadDetailsList,
+    hostName,
+    sessionId,
+    salesforceUrl: hostName
+  });
+  const options = {
+    hostname: 'cloud-doc-stateless.herokuapp.com',
+    path: '/platform/files/download/',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload),
+    }
+  };
+  const request = https.request(options, (res) => {
+    console.log({res})
+  });
+  request.write(payload);
+  request.end();
+  console.log('Payload sent: ', payload);
 }
 
 function escapeString(str) {

--- a/legacy/PimProductListHelper.js
+++ b/legacy/PimProductListHelper.js
@@ -1,6 +1,10 @@
 const PimProductManager = require('./PimProductManager');
 const PimProductService = require('./PimProductService');
-const { prependCDNToViewLink } = require('./utils');
+const {
+  DA_DOWNLOAD_DETAIL_KEY,
+  DADownloadDetails,
+  prependCDNToViewLink
+} = require('./utils');
 
 let helper;
 let service;
@@ -11,6 +15,7 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
   helper = pHelper;
   service = pService;
 
+  let daDownloadDetailsList;
   const recordIds = reqBody.recordIds;
   const vvIds = reqBody.variantValueIds;
   const categoryId = reqBody.categoryId;
@@ -83,6 +88,11 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
         reqBody
       );
     }
+  
+    if (attributeResults.has(DA_DOWNLOAD_DETAIL_KEY)) {
+        daDownloadDetailsList = attributeResults.get(DA_DOWNLOAD_DETAIL_KEY);
+        attributeResults.delete(DA_DOWNLOAD_DETAIL_KEY);
+    }
 
     // sort the export records to the same format as product list page
     exportRecordsAndColumns[0].sort((a, b) =>
@@ -129,12 +139,15 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
     }
   }
 
-  return await addExportColumns(
-    reqBody,
-    templateFields,
-    templateHeaders,
-    exportRecordsAndColumns
-  );
+  return {
+    daDownloadDetailsList,
+    recordsAndCols: await addExportColumns(
+      reqBody,
+      templateFields,
+      templateHeaders,
+      exportRecordsAndColumns
+    )
+  };
 }
 
 // PIM repo ProductPQLHelper.getRecordByCategory()
@@ -356,47 +369,53 @@ async function getResultForProductMap(
 ) {
   let results = new Map();
   let tempMap = new Map();
+  const daDownloadDetailsList = [];
   let variantToAttributeMap = await getVariantMap(productsList);
   const digitalAssetList = await service.simpleQuery(
     helper.namespaceQuery(
-      `select Id, View_Link__c
+      `select Id, Name, External_File_Id__c, View_Link__c
       from Digital_Asset__c`
     )
   );
   const digitalAssetMap = new Map(
     digitalAssetList.map(asset => {
-      return [asset.Id, helper.getValue(asset, 'View_Link__c')];
+      return [asset.Id, asset];
     })
   );
+  console.log({ digitalAssetMap });
 
   for (let product of Array.from(productMap.values())) {
     tempMap = new Map();
-    if (helper.getValue(product, 'Attributes__r') !== null) {
-      for (let attribute of helper.getValue(product, 'Attributes__r').records) {
-        if (
-          helper.getValue(attribute, 'Overwritten_Variant_Value__c') === null &&
-          helper.getValue(attribute, 'Attribute_Label__r') !== null
-        ) {
-          let attributeValueValue = helper.getValue(attribute, 'Value__c');
-          // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
-          if (
-            helper.getValue(attribute, 'Attribute_Label__r.Type__c') === DA_TYPE
-          ) {
-            // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-            const viewLink = digitalAssetMap.get(attributeValueValue);
-            if (viewLink) {
-              // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
-              attributeValueValue = viewLink.includes('https')
-                ? viewLink
-                : await prependCDNToViewLink(viewLink, reqBody);
-            }
-          }
-          tempMap.set(
-            helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
-            attributeValueValue
-          );
+    if (helper.getValue(product, 'Attributes__r') === null) continue;
+
+    for (let attribute of helper.getValue(product, 'Attributes__r').records) {
+      console.log({ attribute });
+
+      if (
+        helper.getValue(attribute, 'Overwritten_Variant_Value__c') !== null ||
+        helper.getValue(attribute, 'Attribute_Label__r') === null
+      )  continue;
+
+      let attrValValue = helper.getValue(attribute, 'Value__c');
+      // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
+      if (
+        helper.getValue(attribute, 'Attribute_Label__r.Type__c') === DA_TYPE
+      ) {
+        const digitalAsset = digitalAssetMap.get(attrValValue);
+        // get view_link__c field of Digital_Asset__c object with id of attrValValue
+        if (digitalAsset) {
+          daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+          const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
+          // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
+          attrValValue = viewLink.includes('https')
+            ? viewLink
+            : await prependCDNToViewLink(viewLink, reqBody);
         }
       }
+      tempMap.set(
+        helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
+        attrValValue
+      );
     }
     results.set(product.Id, tempMap);
   }
@@ -404,7 +423,7 @@ async function getResultForProductMap(
   let variantValueDetailMap = await getVariantValueDetailMap(productsList);
   let tempVariantValue;
   let tempVariantMap = new Map();
-  variantValueIds = variantValueIds.replace(/'/g, '').split(',');
+  variantValueIds = variantValueIds?.replace(/'/g, '').split(',');
   for (let vvId of variantValueIds) {
     tempVariantValue = variantValueDetailMap.get(vvId);
     tempVariantMap = new Map(
@@ -416,58 +435,67 @@ async function getResultForProductMap(
         .getValue(tempVariantValue, 'Parent_Value_Path__c')
         .split(',')) {
         // for each parent, add their overwritten attribute values
-        if (variantToAttributeMap.has(pathVVId)) {
+        if (!variantToAttributeMap.has(pathVVId)) continue;
+        
           for (let attribute of variantToAttributeMap.get(pathVVId)) {
-            let attributeValueValue = helper.getValue(attribute, 'Value__c');
-            // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
-            if (
-              helper.getValue(attribute, 'Attribute_Label__r.Type__c') ===
-              DA_TYPE
-            ) {
-              // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-              const viewLink = digitalAssetMap.get(attributeValueValue);
-              if (viewLink) {
-                // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
-                attributeValueValue = viewLink.includes('https')
-                  ? viewLink
-                  : await prependCDNToViewLink(viewLink, reqBody);
-              }
-            }
-            tempVariantMap.set(
-              helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
-              attributeValueValue
-            );
-          }
-        }
-      }
-    }
-
-    if (variantToAttributeMap.has(vvId)) {
-      for (let attribute of variantToAttributeMap.get(vvId)) {
-        if (helper.getValue(attribute, 'Attribute_Label__r')) {
-          let attributeValueValue = helper.getValue(attribute, 'Value__c');
+          let attrValValue = helper.getValue(attribute, 'Value__c');
           // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
           if (
-            helper.getValue(attribute, 'Attribute_Label__r.Type__c') === DA_TYPE
+            helper.getValue(attribute, 'Attribute_Label__r.Type__c') ===
+            DA_TYPE
           ) {
-            // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-            const viewLink = digitalAssetMap.get(attributeValueValue);
-            if (viewLink) {
+            const digitalAsset = digitalAssetMap.get(attrValValue);
+            // get view_link__c field of Digital_Asset__c object with id of attrValValue
+            if (digitalAsset) {
+              daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+              const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
               // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
-              attributeValueValue = viewLink.includes('https')
+              attrValValue = viewLink.includes('https')
                 ? viewLink
                 : await prependCDNToViewLink(viewLink, reqBody);
             }
           }
           tempVariantMap.set(
             helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
-            attributeValueValue
+            attrValValue
           );
         }
       }
     }
+
+    if (variantToAttributeMap.has(vvId)) {
+      for (let attribute of variantToAttributeMap.get(vvId)) {
+        if (!helper.getValue(attribute, 'Attribute_Label__r')) continue;
+
+        let attrValValue = helper.getValue(attribute, 'Value__c');
+        // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
+        if (
+          helper.getValue(attribute, 'Attribute_Label__r.Type__c') === DA_TYPE
+        ) {
+          const digitalAsset = digitalAssetMap.get(attrValValue);
+          // get view_link__c field of Digital_Asset__c object with id of attrValValue
+          if (digitalAsset) {
+            daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+            const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
+            // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
+            attrValValue = viewLink.includes('https')
+              ? viewLink
+              : await prependCDNToViewLink(viewLink, reqBody);
+          }
+        }
+        tempVariantMap.set(
+          helper.getValue(attribute, 'Attribute_Label__r.Primary_Key__c'),
+          attrValValue
+        );
+      }
+    }
     results.set(vvId, tempVariantMap);
   }
+
+  if (daDownloadDetailsList.length > 0) {
+    results.set(DA_DOWNLOAD_DETAIL_KEY, daDownloadDetailsList);
+  }
+
   return results;
 }
 

--- a/legacy/PimProductListHelper.js
+++ b/legacy/PimProductListHelper.js
@@ -62,8 +62,9 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
 
     let attributeResults = new Map();
     if (variantValueIds.size > 0) {
-      variantValueIds = Array.from(variantValueIds);
-      variantValueIds = variantValueIds.map(id => `'${id}'`).join(',');
+      const stringifiedQuotedVariantValueIds = Array.from(variantValueIds)
+        .map(id => `'${id}'`)
+        .join(',');
       let variantValues = await service.queryExtend(
         helper.namespaceQuery(
           `select Id, Variant__r.Product__c
@@ -71,27 +72,28 @@ async function PimProductListHelper(reqBody, pHelper, pService) {
           where Id IN (${service.QUERY_LIST})
         `
         ),
-        variantValueIds.split(',')
+        stringifiedQuotedVariantValueIds.split(',')
       );
       variantValues.forEach(value => {
         productIdSet.add(helper.getValue(value, 'Variant__r.Product__c'));
       });
-      const productIds = Array.from(productIdSet)
-        .map(id => `'${id}'`)
-        .join(',');
-      let productsList = await PimProductManager(productIds, helper, service);
-      let productMap = await getProductMap(productsList);
-      attributeResults = await getResultForProductMap(
-        productMap,
-        variantValueIds,
-        productsList,
-        reqBody
-      );
     }
-  
+
+    const productIds = Array.from(productIdSet)
+      .map(id => `'${id}'`)
+      .join(',');
+    let productsList = await PimProductManager(productIds, helper, service);
+    let productMap = await getProductMap(productsList);
+    attributeResults = await getResultForProductMap(
+      productMap,
+      variantValueIds,
+      productsList,
+      reqBody
+    );
+
     if (attributeResults.has(DA_DOWNLOAD_DETAIL_KEY)) {
-        daDownloadDetailsList = attributeResults.get(DA_DOWNLOAD_DETAIL_KEY);
-        attributeResults.delete(DA_DOWNLOAD_DETAIL_KEY);
+      daDownloadDetailsList = attributeResults.get(DA_DOWNLOAD_DETAIL_KEY);
+      attributeResults.delete(DA_DOWNLOAD_DETAIL_KEY);
     }
 
     // sort the export records to the same format as product list page
@@ -423,7 +425,6 @@ async function getResultForProductMap(
   let variantValueDetailMap = await getVariantValueDetailMap(productsList);
   let tempVariantValue;
   let tempVariantMap = new Map();
-  variantValueIds = variantValueIds?.replace(/'/g, '').split(',');
   for (let vvId of variantValueIds) {
     tempVariantValue = variantValueDetailMap.get(vvId);
     tempVariantMap = new Map(

--- a/legacy/PimProductService.js
+++ b/legacy/PimProductService.js
@@ -14,7 +14,7 @@ async function getResultForProductStructure(productsList) {
   let variantStructure = await getVariantStructure(productsList);
   let tempMap;
   let variantsList = [];
-  Array.from(productMap.values()).forEach((product) => {
+  Array.from(productMap.values()).forEach(product => {
     tempMap = new Map();
     tempMap.set('Id', product.Id);
     tempMap.set('Product_ID', product.Name);
@@ -27,7 +27,7 @@ async function getResultForProductStructure(productsList) {
 
     variantsList = variantStructure.get(product.Id);
     if (variantsList != null) {
-      variantsList.forEach((variant) => {
+      variantsList.forEach(variant => {
         if (helper.getValue(variant, 'Variant_Values__r') != null) {
           let value;
           for (
@@ -53,7 +53,7 @@ async function getResultForProductStructure(productsList) {
             tempMap.set('Category__c', helper.getValue(product, 'Category__c'));
             productVariantValueMapList = [
               ...productVariantValueMapList,
-              tempMap,
+              tempMap
             ];
           }
         }
@@ -66,7 +66,7 @@ async function getResultForProductStructure(productsList) {
 // PIM repo ProductManager.getProductMap
 async function getProductMap(productsList) {
   let productMap = new Map();
-  productsList.forEach((product) => {
+  productsList.forEach(product => {
     productMap.set(product.Id, product);
   });
   return productMap;
@@ -76,10 +76,10 @@ async function getProductMap(productsList) {
 async function getVariantStructure(productsList) {
   let productsIds = [];
   let variantsList = [];
-  productsList.forEach((product) => {
+  productsList.forEach(product => {
     productsIds.push(product.Id);
   });
-  productsIds = productsIds.map((id) => `'${id}'`).join(',');
+  productsIds = productsIds.map(id => `'${id}'`).join(',');
   if (productsIds.length > 0) {
     variantsList = await service.simpleQuery(
       helper.namespaceQuery(
@@ -101,13 +101,13 @@ async function getVariantStructure(productsList) {
   }
 
   let variantStructure = new Map();
-  variantsList.forEach((variant) => {
+  variantsList.forEach(variant => {
     if (!variantStructure.has(helper.getValue(variant, 'Product__c'))) {
       variantStructure.set(helper.getValue(variant, 'Product__c'), []);
     }
     variantStructure.set(helper.getValue(variant, 'Product__c'), [
       ...variantStructure.get(helper.getValue(variant, 'Product__c')),
-      variant,
+      variant
     ]);
   });
   return variantStructure;

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -3,7 +3,10 @@ const PimProductService = require('./PimProductService');
 const PimProductListHelper = require('./PimProductListHelper');
 const PimExportHelper = require('./PimExportHelper');
 const ForceService = require('./ForceService');
-const { prependCDNToViewLink } = require('./utils');
+const {
+  DADownloadDetails,
+  prependCDNToViewLink
+} = require('./utils');
 
 let helper;
 let service;
@@ -22,6 +25,7 @@ async function PimStructure(reqBody, isListPageExport) {
   let currentVariantName;
 
   if (isListPageExport) {
+    console.log('LIST')
     // export is from product list page
     exportRecordsAndCols = await PimProductListHelper(reqBody, helper, service);
     return exportRecordsAndCols;
@@ -67,44 +71,43 @@ async function PimStructure(reqBody, isListPageExport) {
       )
     );
 
+    const daDownloadDetailsList = [];
     const digitalAssetList = await service.simpleQuery(
-      helper.namespaceQuery(
-        `select Id, View_Link__c
+    helper.namespaceQuery(
+      `select Id, Name, External_File_Id__c, View_Link__c
         from Digital_Asset__c`
-      )
-    );
+    )
+  );
     const digitalAssetMap = new Map(
       digitalAssetList.map(asset => {
-        return [asset.Id, helper.getValue(asset, 'View_Link__c')];
+        return [asset.Id, asset];
       })
     );
 
-    let attributeValueValue;
+    let attrValValue;
     for (let i = 0; i < appearingLabels.length; i++) {
       // add the base product's attribute values
       for (let j = 0; j < appearingValues.length; j++) {
         if (
-          helper.getValue(appearingValues[j], 'Attribute_Label__c') ===
-            appearingLabels[i].Id &&
-          helper.getValue(appearingValues[j], 'Product__c') ===
-            exportRecords[0].get('Id')
+          helper.getValue(appearingValues[j], 'Attribute_Label__c') !== appearingLabels[i].Id ||
+          helper.getValue(appearingValues[j], 'Product__c') !== exportRecords[0].get('Id')
+        ) continue;
+        attrValValue = helper.getValue(appearingValues[j], 'Value__c');
+        if (
+          helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') === DA_TYPE
         ) {
-          attributeValueValue = helper.getValue(appearingValues[j], 'Value__c');
-          if (
-            helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') ===
-            DA_TYPE
-          ) {
-            // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-            const viewLink = digitalAssetMap.get(attributeValueValue);
-            if (viewLink) {
-              // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
-              attributeValueValue = viewLink.includes('https')
-                ? viewLink
-                : await prependCDNToViewLink(viewLink, reqBody);
-            }
+          const digitalAsset = digitalAssetMap.get(attrValValue);
+          // get view_link__c field of Digital_Asset__c object with id of attrValValue
+          if (digitalAsset) {
+            daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+            const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
+            // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
+            attrValValue = viewLink.includes('https')
+              ? viewLink
+              : await prependCDNToViewLink(viewLink, reqBody);
           }
-          exportRecords[0].set(appearingLabels[i].Name, attributeValueValue);
         }
+        exportRecords[0].set(appearingLabels[i].Name, attrValValue);
       }
 
       if (!exportRecords[0].has(appearingLabels[i].Name)) {
@@ -178,9 +181,11 @@ async function PimStructure(reqBody, isListPageExport) {
                   'Attribute_Label_Type__c'
                 ) === DA_TYPE
               ) {
-                // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-                const viewLink = digitalAssetMap.get(attributeValueValue);
-                if (viewLink) {
+                const digitalAsset = digitalAssetMap.get(attrValValue);
+                // get view_link__c field of Digital_Asset__c object with id of attrValValue
+                if (digitalAsset) {
+                  daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+                  const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
                   // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
                   newValue = viewLink.includes('https')
                     ? viewLink
@@ -298,9 +303,11 @@ async function PimStructure(reqBody, isListPageExport) {
                 'Attribute_Label_Type__c'
               ) === DA_TYPE
             ) {
-              // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-              const viewLink = digitalAssetMap.get(attributeValueValue);
-              if (viewLink) {
+              const digitalAsset = digitalAssetMap.get(attrValValue);
+              // get view_link__c field of Digital_Asset__c object with id of attrValValue
+              if (digitalAsset) {
+                daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+                const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
                 // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
                 newValue = viewLink.includes('https')
                   ? viewLink
@@ -330,7 +337,8 @@ async function PimStructure(reqBody, isListPageExport) {
         appearingLabels,
         currentVariantName,
         reqBody,
-        digitalAssetMap
+        digitalAssetMap,
+        daDownloadDetailsList
       );
       exportRecordsAndCols = [filledInData];
     } else {
@@ -350,12 +358,15 @@ async function PimStructure(reqBody, isListPageExport) {
         }
       }
     }
-    return await addExportColumns(
-      productVariantValueMapList,
-      templateFields,
-      templateHeaders,
-      exportRecordsAndCols
-    );
+    return {
+      daDownloadDetailsList,
+      recordsAndCols: await addExportColumns(
+        reqBody,
+        templateFields,
+        templateHeaders,
+        exportRecordsAndColumns
+      )
+    };
   }
 }
 
@@ -410,7 +421,8 @@ async function fillInInheritedData(
   appearingLabels,
   currentVariantName,
   reqBody,
-  digitalAssetMap
+  digitalAssetMap,
+  daDownloadDetailsList
 ) {
   if (exportType === 'currentVariant') {
     exportType = 'allVariants';
@@ -432,14 +444,14 @@ async function fillInInheritedData(
     let newVariant = new Map();
     let varList = Array.from(variantAndValueListMap.keys());
     valuesList = [];
-    Array.from(variantAndValueListMap.values()).forEach(valList => {
+    Array.from(variantAndValueListMap.values()).forEach((valList) => {
       valuesList.push.apply(valuesList, valList); // flatten array
     });
     let valuesIdList = [];
-    valuesList.forEach(val => {
+    valuesList.forEach((val) => {
       valuesIdList.push(val.Id);
     });
-    valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
+    valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
     const overwrittenValues = await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -493,7 +505,7 @@ async function fillInInheritedData(
       if (overwrittenValues.length > 0) {
         for (let j = 0; j < overwrittenValues.length; j++) {
           let affectedLabelName;
-          appearingLabels.forEach(label => {
+          appearingLabels.forEach((label) => {
             if (
               label.Id ===
               helper.getValue(overwrittenValues[j], 'Attribute_Label__c')
@@ -510,9 +522,11 @@ async function fillInInheritedData(
             helper.getValue(overwrittenValues[j], 'Attribute_Label_Type__c') ===
             DA_TYPE
           ) {
-            // get view_link__c field of Digital_Asset__c object with id of attributeValueValue
-            const viewLink = digitalAssetMap.get(attributeValueValue);
-            if (viewLink) {
+            const digitalAsset = digitalAssetMap.get(attrValValue);
+            // get view_link__c field of Digital_Asset__c object with id of attrValValue
+            if (digitalAsset) {
+              daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+              const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
               // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
               newValue = viewLink.includes('https')
                 ? viewLink
@@ -536,7 +550,7 @@ async function fillInInheritedData(
 
   // loop through base product's data
   let baseProductData = new Map();
-  Array.from(baseProduct.keys()).forEach(key => {
+  Array.from(baseProduct.keys()).forEach((key) => {
     if (baseProduct.get(key) != null && baseProduct.get(key) != '') {
       // baseProduct has value for that attribute
       baseProductData.set(key, baseProduct.get(key));
@@ -546,10 +560,10 @@ async function fillInInheritedData(
   // loop through baseProduct's children to settle inheritance from base product
   variantValueTree
     .get(baseProduct.get('Product_ID'))
-    .forEach(firstLevelVariant => {
-      exportRecords.forEach(variant => {
+    .forEach((firstLevelVariant) => {
+      exportRecords.forEach((variant) => {
         if (variant.get('Product_ID') === firstLevelVariant) {
-          Array.from(baseProductData.keys()).forEach(key => {
+          Array.from(baseProductData.keys()).forEach((key) => {
             if (
               !variant.has(key) ||
               (variant.has(key) &&
@@ -571,11 +585,11 @@ async function fillInInheritedData(
     });
 
   // loop through each variant (top down) to settle inheritance from parent variants
-  exportRecords.forEach(variant => {
-    variantValueTree.get(variant.get('Product_ID')).forEach(childVariant => {
-      exportRecords.forEach(variantValue => {
+  exportRecords.forEach((variant) => {
+    variantValueTree.get(variant.get('Product_ID')).forEach((childVariant) => {
+      exportRecords.forEach((variantValue) => {
         if (variantValue.get('Product_ID') === childVariant) {
-          Array.from(variant.keys()).forEach(key => {
+          Array.from(variant.keys()).forEach((key) => {
             if (
               !variantValue.has(key) ||
               (variantValue.has(key) &&

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -3,10 +3,7 @@ const PimProductService = require('./PimProductService');
 const PimProductListHelper = require('./PimProductListHelper');
 const PimExportHelper = require('./PimExportHelper');
 const ForceService = require('./ForceService');
-const {
-  DADownloadDetails,
-  prependCDNToViewLink
-} = require('./utils');
+const { DADownloadDetails, prependCDNToViewLink } = require('./utils');
 
 let helper;
 let service;
@@ -25,7 +22,6 @@ async function PimStructure(reqBody, isListPageExport) {
   let currentVariantName;
 
   if (isListPageExport) {
-    console.log('LIST')
     // export is from product list page
     exportRecordsAndCols = await PimProductListHelper(reqBody, helper, service);
     return exportRecordsAndCols;
@@ -73,11 +69,11 @@ async function PimStructure(reqBody, isListPageExport) {
 
     const daDownloadDetailsList = [];
     const digitalAssetList = await service.simpleQuery(
-    helper.namespaceQuery(
-      `select Id, Name, External_File_Id__c, View_Link__c
+      helper.namespaceQuery(
+        `select Id, Name, External_File_Id__c, View_Link__c
         from Digital_Asset__c`
-    )
-  );
+      )
+    );
     const digitalAssetMap = new Map(
       digitalAssetList.map(asset => {
         return [asset.Id, asset];
@@ -89,17 +85,23 @@ async function PimStructure(reqBody, isListPageExport) {
       // add the base product's attribute values
       for (let j = 0; j < appearingValues.length; j++) {
         if (
-          helper.getValue(appearingValues[j], 'Attribute_Label__c') !== appearingLabels[i].Id ||
-          helper.getValue(appearingValues[j], 'Product__c') !== exportRecords[0].get('Id')
-        ) continue;
+          helper.getValue(appearingValues[j], 'Attribute_Label__c') !==
+            appearingLabels[i].Id ||
+          helper.getValue(appearingValues[j], 'Product__c') !==
+            exportRecords[0].get('Id')
+        )
+          continue;
         attrValValue = helper.getValue(appearingValues[j], 'Value__c');
         if (
-          helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') === DA_TYPE
+          helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') ===
+          DA_TYPE
         ) {
           const digitalAsset = digitalAssetMap.get(attrValValue);
           // get view_link__c field of Digital_Asset__c object with id of attrValValue
           if (digitalAsset) {
-            daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+            daDownloadDetailsList.push(
+              new DADownloadDetails(digitalAsset, reqBody.namespace)
+            );
             const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
             // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
             attrValValue = viewLink.includes('https')
@@ -184,8 +186,13 @@ async function PimStructure(reqBody, isListPageExport) {
                 const digitalAsset = digitalAssetMap.get(attrValValue);
                 // get view_link__c field of Digital_Asset__c object with id of attrValValue
                 if (digitalAsset) {
-                  daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
-                  const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
+                  daDownloadDetailsList.push(
+                    new DADownloadDetails(digitalAsset, reqBody.namespace)
+                  );
+                  const viewLink = helper.getValue(
+                    digitalAsset,
+                    'View_Link__c'
+                  );
                   // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
                   newValue = viewLink.includes('https')
                     ? viewLink
@@ -306,7 +313,9 @@ async function PimStructure(reqBody, isListPageExport) {
               const digitalAsset = digitalAssetMap.get(attrValValue);
               // get view_link__c field of Digital_Asset__c object with id of attrValValue
               if (digitalAsset) {
-                daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+                daDownloadDetailsList.push(
+                  new DADownloadDetails(digitalAsset, reqBody.namespace)
+                );
                 const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
                 // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
                 newValue = viewLink.includes('https')
@@ -444,14 +453,14 @@ async function fillInInheritedData(
     let newVariant = new Map();
     let varList = Array.from(variantAndValueListMap.keys());
     valuesList = [];
-    Array.from(variantAndValueListMap.values()).forEach((valList) => {
+    Array.from(variantAndValueListMap.values()).forEach(valList => {
       valuesList.push.apply(valuesList, valList); // flatten array
     });
     let valuesIdList = [];
-    valuesList.forEach((val) => {
+    valuesList.forEach(val => {
       valuesIdList.push(val.Id);
     });
-    valuesIdList = valuesIdList.map((id) => `'${id}'`).join(',');
+    valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
     const overwrittenValues = await service.simpleQuery(
       helper.namespaceQuery(
         `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
@@ -505,7 +514,7 @@ async function fillInInheritedData(
       if (overwrittenValues.length > 0) {
         for (let j = 0; j < overwrittenValues.length; j++) {
           let affectedLabelName;
-          appearingLabels.forEach((label) => {
+          appearingLabels.forEach(label => {
             if (
               label.Id ===
               helper.getValue(overwrittenValues[j], 'Attribute_Label__c')
@@ -525,7 +534,9 @@ async function fillInInheritedData(
             const digitalAsset = digitalAssetMap.get(attrValValue);
             // get view_link__c field of Digital_Asset__c object with id of attrValValue
             if (digitalAsset) {
-              daDownloadDetailsList.push(new DADownloadDetails(digitalAsset, reqBody.namespace));
+              daDownloadDetailsList.push(
+                new DADownloadDetails(digitalAsset, reqBody.namespace)
+              );
               const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
               // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
               newValue = viewLink.includes('https')
@@ -550,7 +561,7 @@ async function fillInInheritedData(
 
   // loop through base product's data
   let baseProductData = new Map();
-  Array.from(baseProduct.keys()).forEach((key) => {
+  Array.from(baseProduct.keys()).forEach(key => {
     if (baseProduct.get(key) != null && baseProduct.get(key) != '') {
       // baseProduct has value for that attribute
       baseProductData.set(key, baseProduct.get(key));
@@ -560,10 +571,10 @@ async function fillInInheritedData(
   // loop through baseProduct's children to settle inheritance from base product
   variantValueTree
     .get(baseProduct.get('Product_ID'))
-    .forEach((firstLevelVariant) => {
-      exportRecords.forEach((variant) => {
+    .forEach(firstLevelVariant => {
+      exportRecords.forEach(variant => {
         if (variant.get('Product_ID') === firstLevelVariant) {
-          Array.from(baseProductData.keys()).forEach((key) => {
+          Array.from(baseProductData.keys()).forEach(key => {
             if (
               !variant.has(key) ||
               (variant.has(key) &&
@@ -585,11 +596,11 @@ async function fillInInheritedData(
     });
 
   // loop through each variant (top down) to settle inheritance from parent variants
-  exportRecords.forEach((variant) => {
-    variantValueTree.get(variant.get('Product_ID')).forEach((childVariant) => {
-      exportRecords.forEach((variantValue) => {
+  exportRecords.forEach(variant => {
+    variantValueTree.get(variant.get('Product_ID')).forEach(childVariant => {
+      exportRecords.forEach(variantValue => {
         if (variantValue.get('Product_ID') === childVariant) {
-          Array.from(variant.keys()).forEach((key) => {
+          Array.from(variant.keys()).forEach(key => {
             if (
               !variantValue.has(key) ||
               (variantValue.has(key) &&

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -2,15 +2,16 @@ var http = require('https');
 var fs = require('fs');
 const PimExportHelper = require('./PimExportHelper');
 const ForceService = require('./ForceService');
+const DA_DOWNLOAD_DETAIL_KEY = 'DA_DOWNLOAD_DETAIL_KEY';
 
 class DADownloadDetails {
   static helper;
   constructor(asset, namespace) {
     if (this.helper == null) this.helper = new PimExportHelper(namespace);
 
-    this.fileName = helper.getValue(asset, 'Name');
-    this.fileId = helper.getValue(asset, 'External_File_Id__c');
-    this.key = helper.getValue(asset, 'View_Link__c');
+    this.fileName = this.helper.getValue(asset, 'Name');
+    this.fileId = this.helper.getValue(asset, 'External_File_Id__c');
+    this.key = this.helper.getValue(asset, 'View_Link__c');
   }
 }
 
@@ -24,6 +25,7 @@ module.exports = {
   validateNamespaceForField,
   prependCDNToViewLink,
   DADownloadDetails,
+  DA_DOWNLOAD_DETAIL_KEY
 };
 /**
  * Function that send zip file to salesforce chatter via chatter api

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -3,6 +3,17 @@ var fs = require('fs');
 const PimExportHelper = require('./PimExportHelper');
 const ForceService = require('./ForceService');
 
+class DADownloadDetails {
+  static helper;
+  constructor(asset, namespace) {
+    if (this.helper == null) this.helper = new PimExportHelper(namespace);
+
+    this.fileName = helper.getValue(asset, 'Name');
+    this.fileId = helper.getValue(asset, 'External_File_Id__c');
+    this.key = helper.getValue(asset, 'View_Link__c');
+  }
+}
+
 module.exports = {
   postToChatter,
   getNestedField,
@@ -11,7 +22,8 @@ module.exports = {
   removeFileFromDisk,
   validateNamespaceForPath,
   validateNamespaceForField,
-  prependCDNToViewLink
+  prependCDNToViewLink,
+  DADownloadDetails,
 };
 /**
  * Function that send zip file to salesforce chatter via chatter api

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -9,7 +9,7 @@ class DADownloadDetails {
   constructor(asset, namespace) {
     if (this.helper == null) this.helper = new PimExportHelper(namespace);
 
-    this.fileName = this.helper.getValue(asset, 'Name');
+    this.fileName = asset.Name;
     this.fileId = this.helper.getValue(asset, 'External_File_Id__c');
     this.key = this.helper.getValue(asset, 'View_Link__c');
   }


### PR DESCRIPTION
New feature:
- When Attribute Labels that are typed Digital Assets are in the export columns, if there are Attribute Values i.e. S3 assets, send a request to the Cloud File Storage Heroku app for it to download, zip and post the assets to chatter.

Fix:
- When top-level products are exported with NO variants, their Attribute Values are missing in the export. This PR makes sure they are added in the eventual XLSX.

Couple of refactorings as well to try to make the code a little more friendly.
Supported by https://github.com/PropelPLM/CloudFileStorage/pull/24 and https://github.com/PropelPLM/PIM/pull/567