### PR TITLE
PIM-613: Export | PDP page export error

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -370,7 +370,7 @@ async function PimStructure(reqBody, isListPageExport) {
     return {
       daDownloadDetailsList,
       recordsAndCols: await addExportColumns(
-        reqBody,
+        productVariantValueMapList,
         templateFields,
         templateHeaders,
         exportRecordsAndColumns


### PR DESCRIPTION
When doing the binary export, I mistook the calls to `addExportColumns` be identical. Changed the parameters back to the original for PDP export.