### PR TITLE
PIM-654 bug with import

### DIFF
--- a/data/product_data.csv
+++ b/data/product_data.csv
@@ -1,5 +1,4 @@
-product_id,parent_id,v_level,manufacturer_id,lifecycle_stage,release_status,active_quality_issues,highest_level_product_id,category_id,variant_0,variant_1,variant_2
-Mikes_Parent_12,,0,Manufacture-id -Printer Parent-1,In Progress,Not Released,None,,83988,Color,Size,Shipping
-Mikes_child_12,Mikes_Parent_12,1,Manufacture-id -DR-Printer child-1-1,,,,Mikes_Parent_12,83988,Blue,,,
-Mikes_grandchild_12,Mikes_child_12,2,Manufacture-id -DR-Printer grandchild-1-11-6,Complete,In Review,,Mikes_Parent_12,83988,,Small,
-Mikes_grand_grandchild_12,Mikes_grandchild_12,3,Manufacture-id -DR-Printer grandchild-1-11-6,Complete,In Review,,Mikes_Parent_12,83988,,,ground
+product_id,parent_id,v_level,manufacturer_id,lifecycle_stage,release_status,active_quality_issues,highest_level_product_id,category_id,variant_0,variant_1,
+Try_test,,0,Manufacture-id -Printer Parent-1,In Progress,Not Released,None,,11011,,,
+Try_test_child,Try_test,1,Manufacture-id -DR-Printer child-1-1,,,,Try_test,11011,black,,
+Try_test_grandchild,Try_test_child,2,Manufacture-id -DR-Printer grandchild-1-11-6,Complete,In Review,,Try_test,11011,,small,

--- a/lib/ImportProduct.js
+++ b/lib/ImportProduct.js
@@ -293,8 +293,8 @@ class ImportProduct {
                 tmpVariantValue[this.helper.namespace('Label__c')] = node[key]
 
                 this.productHasVariantMap.get(node.highest_level_product_id).records.forEach(variant => {
-                  if (variant.Name === this.nodeMapLevelZero[node.highest_level_product_id][key]) {
-                    tmpVariantId = variant.Id
+                  if (variant[this.helper.namespace('Order__c')] === parseInt(key.substring(8)) + 1) {
+                    tmpVariantId = variant.Id;
                   }
                 })
                 tmpVariantValue[this.helper.namespace('Variant__c')] = tmpVariantId

--- a/local/testImportProduct.js
+++ b/local/testImportProduct.js
@@ -1,10 +1,10 @@
 const fs = require('fs')
 const ImportProduct = require('../lib/ImportProduct');
 // replace with your test org metadata
-const hostUrl = "pim-uat.my.salesforce.com"
-const namespace = "PIM"
+const hostUrl = "paas-espresso-3568-dev-ed.scratch.my.salesforce.com"
+const namespace = ""
 const orgId = "00D8c00000868mL"
-const sessionId = "00D8c00000868mL!AR0AQPCnxBX27z2PLFtfRhddeAPKZdl7wkPv3q0bF.zPufapVb2uUGVbhWQH.6a0otHhlzhMcbiOldFZuWZtbEDmSXfAmfot"
+const sessionId = "00DDP000005yxZa!ARIAQE8Ty0cwFI51CqiK2VEoT7vBL2e5LO.ZTtcqcczwoBmgXIfS5SRZhuKgVfUWKQNgMQA_m_WrX.Z..yTKopbjUwug1Ipz"
 
 function productTest() {
   let treq = {

--- a/service/PimProduct.js
+++ b/service/PimProduct.js
@@ -18,7 +18,7 @@ class PimProduct {
 
       const result = await this.helper.connection.simpleQuery(this.helper.namespaceQuery(
         `select Id, Name, 
-          (select Id, Name from ${this.helper.namespace('Variants__r')}) 
+          (select Id, Name, Order__c from ${this.helper.namespace('Variants__r')}) 
           from Product__c where Name in (${formatedNames})`
       ))
       this.products = result.records


### PR DESCRIPTION
turns out I was relying on the file to provide the data but turns out that the import file will not have the variant data. This update uses the variant data that is in salesforce. So if it's created by the category or if they wan to add the variants with this file they can.