### PR TITLE
PIM-294: PIM | Export | New export format XLSX

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -164,24 +164,24 @@ async function PimStructure(reqBody, isListPageExport) {
 
           // add any overwritten values
           if (overwrittenValues.length > 0) {
-            for (let i = 0; i < overwrittenValues.length; i++) {
+            for (let j = 0; j < overwrittenValues.length; j++) {
               let affectedLabelName;
               appearingLabels.forEach(label => {
                 if (
                   label.Id ===
-                  helper.getValue(overwrittenValues[i], 'Attribute_Label__c')
+                  helper.getValue(overwrittenValues[j], 'Attribute_Label__c')
                 ) {
                   affectedLabelName = label.Name;
                 }
               });
               const affectedVariantValue = helper.getValue(
-                overwrittenValues[i],
+                overwrittenValues[j],
                 'Overwritten_Variant_Value__c'
               );
-              let newValue = helper.getValue(overwrittenValues[i], 'Value__c');
+              let newValue = helper.getValue(overwrittenValues[j], 'Value__c');
               if (
                 helper.getValue(
-                  overwrittenValues[i],
+                  overwrittenValues[j],
                   'Attribute_Label_Type__c'
                 ) === DA_TYPE
               ) {


### PR DESCRIPTION
Fixed bug from refactoring export preventing exporting when there are overwritten variant values.
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/77341283/219227559-1d047325-67a5-49da-a89d-6da400a05737.png">
