### PR TITLE
PIM-714: PIM | Export | Export failing in PDP for products without variant values and when filling in inherited data

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -142,17 +142,20 @@ async function PimStructure(reqBody, isListPageExport) {
           valuesIdList.push(val[0].Id);
         });
         valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
-        const overwrittenValues = await service.simpleQuery(
-          helper.namespaceQuery(
-            `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
-            from Attribute_Value__c
-            where (
-              Overwritten_Variant_Value__c IN (${valuesIdList}) AND
-              Product__c IN (${recordIds}) AND
-              Attribute_Label__c IN (${appearingLabelIds})
-            )`
-          )
-        );
+        let overwrittenValues = [];
+        if (valuesIdList.length > 0) {
+          overwrittenValues = await service.simpleQuery(
+            helper.namespaceQuery(
+              `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
+              from Attribute_Value__c
+              where (
+                Overwritten_Variant_Value__c IN (${valuesIdList}) AND
+                Product__c IN (${recordIds}) AND
+                Attribute_Label__c IN (${appearingLabelIds})
+              )`
+            )
+          );
+        }
 
         // add variant values to the current variant product
         for (let i = 0; i < varList.length; i++) {
@@ -185,8 +188,8 @@ async function PimStructure(reqBody, isListPageExport) {
                   'Attribute_Label_Type__c'
                 ) === DA_TYPE
               ) {
-                const digitalAsset = digitalAssetMap.get(attrValValue);
-                // get view_link__c field of Digital_Asset__c object with id of attrValValue
+                const digitalAsset = digitalAssetMap.get(newValue);
+                // get view_link__c field of Digital_Asset__c object with id of newValue
                 if (digitalAsset) {
                   daDownloadDetailsList.push(
                     new DADownloadDetails(digitalAsset, reqBody.namespace)
@@ -240,17 +243,20 @@ async function PimStructure(reqBody, isListPageExport) {
         valuesIdList.push(val.Id);
       });
       valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
-      const overwrittenValues = await service.simpleQuery(
-        helper.namespaceQuery(
-          `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
-          from Attribute_Value__c
-          where (
-            Overwritten_Variant_Value__c IN (${valuesIdList}) AND
-            Product__c IN (${recordIds}) AND
-            Attribute_Label__c IN (${appearingLabelIds})
-          )`
-        )
-      );
+      let overwrittenValues = [];
+      if (valuesIdList.length > 0) {
+        overwrittenValues = await service.simpleQuery(
+          helper.namespaceQuery(
+            `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
+            from Attribute_Value__c
+            where (
+              Overwritten_Variant_Value__c IN (${valuesIdList}) AND
+              Product__c IN (${recordIds}) AND
+              Attribute_Label__c IN (${appearingLabelIds})
+            )`
+          )
+        );
+      }
 
       let currValue;
       let isFirstLevelVariant;
@@ -312,8 +318,8 @@ async function PimStructure(reqBody, isListPageExport) {
                 'Attribute_Label_Type__c'
               ) === DA_TYPE
             ) {
-              const digitalAsset = digitalAssetMap.get(attrValValue);
-              // get view_link__c field of Digital_Asset__c object with id of attrValValue
+              const digitalAsset = digitalAssetMap.get(newValue);
+              // get view_link__c field of Digital_Asset__c object with id of newValue
               if (digitalAsset) {
                 daDownloadDetailsList.push(
                   new DADownloadDetails(digitalAsset, reqBody.namespace)
@@ -482,17 +488,20 @@ async function fillInInheritedData(
       valuesIdList.push(val.Id);
     });
     valuesIdList = valuesIdList.map(id => `'${id}'`).join(',');
-    const overwrittenValues = await service.simpleQuery(
-      helper.namespaceQuery(
-        `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
-        from Attribute_Value__c
-        where (
-          Overwritten_Variant_Value__c IN (${valuesIdList}) AND
-          Product__c IN (${recordIds}) AND
-          Attribute_Label__c IN (${appearingLabelIds})
-        )`
-      )
-    );
+    let overwrittenValues = [];
+    if (valuesIdList.length > 0) {
+      overwrittenValues = await service.simpleQuery(
+        helper.namespaceQuery(
+          `select Id, Attribute_Label__c, Attribute_Label_Type__c, Value__c, Product__c, Overwritten_Variant_Value__c
+          from Attribute_Value__c
+          where (
+            Overwritten_Variant_Value__c IN (${valuesIdList}) AND
+            Product__c IN (${recordIds}) AND
+            Attribute_Label__c IN (${appearingLabelIds})
+          )`
+        )
+      );
+    }
 
     let currValue;
     let isFirstLevelVariant;
@@ -552,8 +561,8 @@ async function fillInInheritedData(
             helper.getValue(overwrittenValues[j], 'Attribute_Label_Type__c') ===
             DA_TYPE
           ) {
-            const digitalAsset = digitalAssetMap.get(attrValValue);
-            // get view_link__c field of Digital_Asset__c object with id of attrValValue
+            const digitalAsset = digitalAssetMap.get(newValue);
+            // get view_link__c field of Digital_Asset__c object with id of newValue
             if (digitalAsset) {
               daDownloadDetailsList.push(
                 new DADownloadDetails(digitalAsset, reqBody.namespace)


### PR DESCRIPTION
- Added null check for variant values (previously assumed users wont select filling in inherited data or exporting all variants if there weren't variant values in the product)
- Fixed typo