### PR TITLE
PIM-476: PIM | Add ability to only download lowest level Variant on Product List page and Product Data page

### DIFF
--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -116,7 +116,10 @@ async function PimRecordListHelper(
           lowestVariantValueIds.includes(record.get('Record_ID'))
         );
       }
+      vvIds.clear();
       variantValues.forEach(value => {
+        // update variant value ids and record ids with only those relevant to lowest variants
+        vvIds.add(value.Id);
         recordIdSet.add(helper.getValue(value, 'Variant__r.Product__c'));
       });
     }


### PR DESCRIPTION
Fixed bug where exporting from PLP sometimes doesnt work (caused by not updating variant value ids set with only lowest variants resulting in it looking for ids of non-lowest variants subsequently)