### PR TITLE
PIM-714: PIM | Export | Export failing in PDP for products without variant values and when filling in inherited data

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -17,7 +17,11 @@ const {
 
 let helper;
 let service;
+const CATEGORY_ID_FIELD = 'Category__c';
+const CATEGORY_NAME_FIELD = 'Category__r.Name';
+const CATEGORY_NAME_LABEL = 'Category';
 const DA_TYPE = 'DigitalAsset';
+const ID_FIELD = 'Id';
 const PRODUCT_REFERENCE_TYPE = 'ProductReference';
 
 class PimStructure {
@@ -766,10 +770,13 @@ class PimStructure {
     let exportColumns = [];
     let templateHeaderValueMap = new Map();
     if (!templateFields || templateFields.length === 0) {
-      // if not template export, push all attribute columns
+      // if not template export, push all attribute columns except sobject id and rename Category__r.Name to Category
       exportColumns = Array.from(productVariantValueMapList[0].keys())
-        .filter(col => col !== 'Id')
+        .filter(col => col !== ID_FIELD && col !== CATEGORY_ID_FIELD)
         .map(col => {
+          if (col === CATEGORY_NAME_FIELD) {
+            return { fieldName: col, label: CATEGORY_NAME_LABEL, type: 'text' };
+          }
           return { fieldName: col, label: col, type: 'text' };
         });
     } else if (templateFields && templateFields.length > 0) {


### PR DESCRIPTION
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/77341283/231333015-0877f9f2-f3ab-4bda-aaf2-c4bd4e5beb1c.png">

Removed `Category__c` id field and renamed `Category__r.Name` label to 'Category' in exported file