### PR TITLE
PIM-884: PIM | Export is using commas in values to delimit columns

### DIFF
--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -191,7 +191,7 @@ function escapeString(str) {
   str = str.toString() ? str.toString() : '';
   let useEnclosingQuotes = str.indexOf(',') > -1;
   if (str.indexOf('"') > 0) {
-    str = str.replace(/['"']/g, '""');
+    str = str.replace(/"/g, '""');
     useEnclosingQuotes = true;
   }
   if (str.indexOf('\n') > -1) {


### PR DESCRIPTION
## Description
- Remove single quotes from regex so they are not converted to double quotes to allow them to be preserved in the exported xlsx

## Demo
<img width="662" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/77341283/233095425-fa59b94e-3849-4558-add2-c1a10eeaed26.png">

## Other PR Link
https://github.com/PropelPLM/propel-document-java/pull/28
