### PR TITLE
PIM-714: PIM | Export | Export failing in PDP for products without variant values and when filling in inherited data

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -39,7 +39,11 @@ class PimStructure {
 
     const asposeInput = { reqBody };
     const isProduct = reqBody.recordType == PRODUCT_TYPE;
-    let currentVariantName, templateFields, templateHeaders, useAspose;
+    let currentVariantName,
+      templateFields,
+      templateHeaders,
+      useAspose,
+      daDownloadDetailsList;
     if (reqBody.options.isTemplateExport) {
       if (reqBody.templateVersionData) {
         ({ templateFields, templateHeaders } = this.getTemplateHeadersAndFields(
@@ -84,14 +88,14 @@ class PimStructure {
         baseRecord = productVariantValueMapList[0],
         exportRecords = [baseRecord],
         exportRecordsAndColumns = [exportRecords],
-        attrValValue,
-        daDownloadDetailsList = initAssetDownloadDetailsList(
-          isProduct,
-          includeRecordAsset,
-          recordList.map(record => record.Id),
-          digitalAssetMap,
-          namespace
-        );
+        attrValValue;
+      daDownloadDetailsList = initAssetDownloadDetailsList(
+        isProduct,
+        includeRecordAsset,
+        recordList.map(record => record.Id),
+        digitalAssetMap,
+        namespace
+      );
       appearingLabelIds = prepareIdsForSOQL(appearingLabelIds);
       const { appearingLabels, appearingValues } =
         await this.parseAppearringAttrLabelsAndValues(


### PR DESCRIPTION
## Description
<img width="729" alt="image" src="https://user-images.githubusercontent.com/77341283/233426598-ba6d7a4b-8d5e-4a34-8073-57a6513452e3.png">
Error with digital assets download during xlsx was caused by calling `daDownloadDetailsList` outside of the scope it was declared in

