### PR TITLE
PIM-895: PIM | Export | Export having issues when first character of attribute value is a double quote

### DIFF
--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -4,6 +4,7 @@ const https = require('https');
 
 const PimStructure = require('./PimStructure');
 const {
+  cleanString,
   postToChatter,
   logErrorResponse,
   sendCsvToAsposeCells
@@ -125,7 +126,7 @@ function convertArrayOfObjectsToCSV(records, columns) {
       ) {
         recordAttributes.set(skey, recordAttributes.get(skey).Name);
       }
-      csvStringResult += escapeString(records[i].get(skey) || '');
+      csvStringResult += cleanString(records[i].get(skey) || '');
 
       counter++;
     }
@@ -184,23 +185,6 @@ async function sendDADownloadRequests(
   request.write(payload);
   request.end();
   console.log('Payload sent: ', payload);
-}
-
-function escapeString(str) {
-  // check for fields which actually contain a quote, newline or comma char, need to protect those
-  str = str.toString() ? str.toString() : '';
-  let useEnclosingQuotes = str.indexOf(',') > -1;
-  if (str.indexOf('"') > 0) {
-    str = str.replace(/"/g, '""');
-    useEnclosingQuotes = true;
-  }
-  if (str.indexOf('\n') > -1) {
-    useEnclosingQuotes = true;
-  }
-  if (useEnclosingQuotes) {
-    str = '"' + str + '"';
-  }
-  return str;
 }
 
 module.exports = LegacyExportPIM;

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -280,23 +280,21 @@ function getNestedField(object, field) {
 }
 
 // Escape special characters for build a clean .CSV file
-function cleanString(value) {
-  if (value !== undefined && value !== null) {
-    value = value.toString();
-    let useEnclosingQuotes = value.indexOf(',') > -1;
-    if (value.indexOf('"') > 0) {
-      value = value.replace(/"/g, '""');
-      useEnclosingQuotes = true;
-    }
-    if (value.indexOf('\n') > -1) {
-      useEnclosingQuotes = true;
-    }
-    if (useEnclosingQuotes) {
-      value = `"${value}"`;
-    }
-    return value;
+function cleanString(str) {
+  // check for fields which actually contain a quote, newline or comma char, need to protect those
+  str = str.toString() ? str.toString() : '';
+  let useEnclosingQuotes = str.indexOf(',') > -1;
+  if (str.includes('"')) {
+    str = str.replace(/"/g, '""');
+    useEnclosingQuotes = true;
   }
-  return '';
+  if (str.indexOf('\n') > -1) {
+    useEnclosingQuotes = true;
+  }
+  if (useEnclosingQuotes) {
+    str = '"' + str + '"';
+  }
+  return str;
 }
 
 function removeFileFromDisk(nameOnDisk) {


### PR DESCRIPTION
## Description
- Fixed the clean string method
- Abstracted string cleaning to utils

## Demo
<img width="600" alt="image" src="https://user-images.githubusercontent.com/77341283/233629370-f0884cf6-602c-4ded-9e11-3cf8f000dbb4.png">
CSV

<img width="569" alt="image" src="https://user-images.githubusercontent.com/77341283/233629524-72f9e10f-6ec3-487e-88b8-0b1fe6eacbe4.png">
XLSX
