### PR TITLE
PIM-926 adding a check for the client Id

### DIFF
--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -23,7 +23,7 @@ async function LegacyExportPIM(req) {
 
   // highjacking the flow here are inserting the session id from the JWT flow
   const response = await propelConnect.jwtSession({
-    clientId: reqBody.clientId,
+    clientId: (reqBody.clientId) ? reqBody.clientId :process.env.PIM_DATA_SERVICE_CLIENT_ID,
     isTest: reqBody.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY,
     user: reqBody.user

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -23,7 +23,7 @@ async function LegacyExportPIM(req) {
 
   // highjacking the flow here are inserting the session id from the JWT flow
   const response = await propelConnect.jwtSession({
-    clientId: process.env.PIM_DATA_SERVICE_CLIENT_ID,
+    clientId: (reqBody.clientId) ? reqBody.clientId : process.env.PIM_DATA_SERVICE_CLIENT_ID, // TODO remove the clientId check after the security review
     isTest: reqBody.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY,
     user: reqBody.user

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -23,7 +23,7 @@ async function LegacyExportPIM(req) {
 
   // highjacking the flow here are inserting the session id from the JWT flow
   const response = await propelConnect.jwtSession({
-    clientId: (reqBody.clientId) ? reqBody.clientId :process.env.PIM_DATA_SERVICE_CLIENT_ID,
+    clientId: process.env.PIM_DATA_SERVICE_CLIENT_ID,
     isTest: reqBody.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY,
     user: reqBody.user

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -13,7 +13,7 @@ function convertDataByType(data, type) {
 
 async function getSessionId(request) {
   const response = await jwtSession({
-    clientId: request.clientId,
+    clientId: (request.clientId) ? request.clientId : process.env.PIM_DATA_SERVICE_CLIENT_ID,
     isTest: request.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY.replace(/\\n/g, '\n'),
     user: request.user

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -13,7 +13,7 @@ function convertDataByType(data, type) {
 
 async function getSessionId(request) {
   const response = await jwtSession({
-    clientId: process.env.PIM_DATA_SERVICE_CLIENT_ID,
+    clientId: (request.clientId) ? request.clientId : process.env.PIM_DATA_SERVICE_CLIENT_ID, // TODO remove the clientId check after the security review
     isTest: request.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY.replace(/\\n/g, '\n'),
     user: request.user

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -13,7 +13,7 @@ function convertDataByType(data, type) {
 
 async function getSessionId(request) {
   const response = await jwtSession({
-    clientId: (request.clientId) ? request.clientId : process.env.PIM_DATA_SERVICE_CLIENT_ID,
+    clientId: process.env.PIM_DATA_SERVICE_CLIENT_ID,
     isTest: request.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY.replace(/\\n/g, '\n'),
     user: request.user

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pim-data-service",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/script/postman/pim-data-service.postman_collection.json
+++ b/script/postman/pim-data-service.postman_collection.json
@@ -14,7 +14,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"batchsize\": 3,\n    \"clientId\": \"3MVG9vDPWAliPr7qI2eOWh9MTRBEzmvX6wKco2wZIs46S42fsNODO7MyZIMxJgQB0qycwRNnwAFCebFZ7Pspf\",\n    \"data\": \"name,classification,rank,category_associations\\nTab A,Product,5,12022\\nTab B,Product,6,12033;11021\\n\",\n    \"isTest\": false,\n    \"mapping\": {},\n    \"namespace\": \"PIM\",\n    \"orgId\": \"00D7i000000UO0T\",\n    \"options\": {},\n    \"skipDB\": true,\n    \"user\": \"test-lwa0dgwoissf@example.com\"\n}",
+					"raw": "{\n    \"batchsize\": 3,\n    \"data\": \"name,classification,rank,category_associations\\nTab A,Product,5,12022\\nTab B,Product,6,12033;11021\\n\",\n    \"isTest\": true,\n    \"mapping\": {},\n    \"namespace\": \"PIM\",\n    \"orgId\": \"00D7i000000UO0T\",\n    \"options\": {},\n    \"skipDB\": true,\n    \"user\": \"test-lwa0dgwoissf@example.com\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -43,7 +43,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"batchsize\": 3,\n    \"clientId\": \"3MVG9vDPWAliPr7qI2eOWh9MTRBEzmvX6wKco2wZIs46S42fsNODO7MyZIMxJgQB0qycwRNnwAFCebFZ7Pspf\",\n    \"data\": \"name,category_id,parent_category,parent_category_id\\nNew Category Import Test - Level 1,43988,Crazy Cool Clothes and More,10000\\nNew Category Import Test - Level 2,43989,New Category Import Test - Level 1,43988\\nNew Category Import Test - Level 3,43990,New Category Import Test - Level 2,43989\\nNew Category Import Test - Level 4,43991,New Category Import Test - Level 3,43990\",\n    \"isTest\": true,\n    \"mapping\": {},\n    \"namespace\": \"PIM\",\n    \"orgId\": \"00D7i000000UO0T\",\n    \"options\": {},\n    \"skipDB\": true,\n    \"user\": \"test-lwa0dgwoissf@example.com\"\n}",
+					"raw": "{\n    \"batchsize\": 3,\n    \"data\": \"name,category_id,parent_category,parent_category_id\\nNew Category Import Test - Level 1,43988,Crazy Cool Clothes and More,10000\\nNew Category Import Test - Level 2,43989,New Category Import Test - Level 1,43988\\nNew Category Import Test - Level 3,43990,New Category Import Test - Level 2,43989\\nNew Category Import Test - Level 4,43991,New Category Import Test - Level 3,43990\",\n    \"isTest\": true,\n    \"mapping\": {},\n    \"namespace\": \"\",\n    \"orgId\": \"00D7i000000UO0T\",\n    \"options\": {},\n    \"skipDB\": true,\n    \"user\": \"test-xqahb6uhwa70@example.com\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -72,7 +72,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"batchsize\": 3,\n    \"clientId\": \"3MVG9vDPWAliPr7qI2eOWh9MTRBEzmvX6wKco2wZIs46S42fsNODO7MyZIMxJgQB0qycwRNnwAFCebFZ7Pspf\",\n    \"data\": \"product_id,parent_id,v_level,manufacturer_id,lifecycle_stage,release_status,active_quality_issues,highest_level_product_id,category_id,variant_0,variant_1\\nTry_test,,0,Manufacture-id -Printer Parent-1,In Progress,Not Released,None,,11011,,\\nTry_test_child,Try_test,1,Manufacture-id -DR-Printer child-1-1,,,,Try_test,11011,black,\\nTry_test_grandchild,Try_test_child,2,Manufacture-id -DR-Printer grandchild-1-11-6,Complete,In Review,,Try_test,11011,,small\\n\",\n    \"isTest\": true,\n    \"mapping\": {},\n    \"namespace\": \"PIM\",\n    \"orgId\": \"00D7i000000UO0T\",\n    \"options\": {},\n    \"skipDB\": true,\n    \"user\": \"test-lwa0dgwoissf@example.com\"\n}",
+					"raw": "{\n    \"batchsize\": 3,\n    \"data\": \"product_id,parent_id,v_level,manufacturer_id,lifecycle_stage,release_status,active_quality_issues,highest_level_product_id,category_id,variant_0,variant_1\\nTry_test,,0,Manufacture-id -Printer Parent-1,In Progress,Not Released,None,,11011,,\\nTry_test_child,Try_test,1,Manufacture-id -DR-Printer child-1-1,,,,Try_test,11011,black,\\nTry_test_grandchild,Try_test_child,2,Manufacture-id -DR-Printer grandchild-1-11-6,Complete,In Review,,Try_test,11011,,small\\n\",\n    \"isTest\": true,\n    \"mapping\": {},\n    \"namespace\": \"PIM\",\n    \"orgId\": \"00D7i000000UO0T\",\n    \"options\": {},\n    \"skipDB\": true,\n    \"user\": \"test-lwa0dgwoissf@example.com\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
I've moved the client Id to Heroku as a env var but wanted to leave the ability to pass the client id into the service is for some reason you needed to do that. Maybe we don't need this, thoughts?

I put the check for clientId back because the code that is being used for our security review still expects the clientId to be passed to Heroku. But when the security review is done then we can remove this check.