### PR TITLE
PIM-910: PIM | Export | Lowest Variants of product export includes main product

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -394,6 +394,8 @@ class PimStructure {
                 valuesList,
                 reqBody.namespace
               );
+              // remove base product from exportRecords
+              exportRecords = [];
               // push only the lowest level variant values (i.e. SKUs)
               lowestLevelVariantValues.forEach(vvId => {
                 if (newVariant.get('Record_ID') === vvId) {
@@ -718,7 +720,8 @@ class PimStructure {
       });
     });
     // remove base product from current variant export
-    return exportType === 'currentVariant' &&
+    return (exportType === 'currentVariant' ||
+      exportType === 'lowestVariants') &&
       reqBody.variantValuePath.length > 0
       ? filledInExportRecords.slice(1)
       : filledInExportRecords;


### PR DESCRIPTION
Remove base product when doing SKU export for both inherited and non inherited export, since it should not show base product just like current variant export.