### PR TITLE
PIM-910: PIM | Export | Lowest Variants of product export includes main product

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -723,10 +723,10 @@ class PimStructure {
         });
       });
     });
-    // remove base product from current variant export
-    return (exportType === 'currentVariant' ||
-      exportType === 'lowestVariants') &&
-      reqBody.variantValuePath.length > 0
+    // remove base product from SKU export or current variant export (if current record is not base product)
+    return (exportType === 'currentVariant' &&
+      reqBody.variantValuePath.length > 0) ||
+      exportType === 'lowestVariants'
       ? filledInExportRecords.slice(1)
       : filledInExportRecords;
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -394,8 +394,6 @@ class PimStructure {
                 valuesList,
                 reqBody.namespace
               );
-              // remove base product from exportRecords
-              exportRecords = [];
               // push only the lowest level variant values (i.e. SKUs)
               lowestLevelVariantValues.forEach(vvId => {
                 if (newVariant.get('Record_ID') === vvId) {
@@ -409,24 +407,30 @@ class PimStructure {
         } else {
           throw 'Invalid Export Type';
         }
-        exportRecordsAndColumns = reqBody.isInherited
-          ? [
-              await this.fillInInheritedData(
-                baseRecord,
-                exportRecords,
-                valuesList,
-                exportType,
-                productVariantValueMapList,
-                recordIds,
-                appearingLabelIds,
-                appearingLabels,
-                currentVariantName,
-                reqBody,
-                digitalAssetMap,
-                daDownloadDetailsList
-              )
-            ]
-          : [exportRecords];
+
+        if (reqBody.isInherited) {
+          exportRecordsAndColumns = [
+            await this.fillInInheritedData(
+              baseRecord,
+              exportRecords,
+              valuesList,
+              exportType,
+              productVariantValueMapList,
+              recordIds,
+              appearingLabelIds,
+              appearingLabels,
+              currentVariantName,
+              reqBody,
+              digitalAssetMap,
+              daDownloadDetailsList
+            )
+          ];
+        } else if (exportType === 'lowestVariants') {
+          // remove base product from list of lowest variants
+          exportRecordsAndColumns = [exportRecords.slice(1)];
+        } else {
+          exportRecordsAndColumns = [exportRecords];
+        }
       }
       exportRecordsColsAndAssets = {
         daDownloadDetailsList,


### PR DESCRIPTION
Moved the removing of base product to after the population of lowest variants

<img width="968" alt="image" src="https://github.com/PropelPLM/pim-data-service/assets/77341283/e0ce91a2-7c58-4dab-8a78-b2dee9655091">
