### PR TITLE
PIM-961: PIM | Export | Template Export Should Dynamically Establish Data Row Containing Attributes

### DIFF
--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -132,6 +132,7 @@ function convertArrayOfObjectsToCSV(records, columns) {
   ];
   for (let headerRow of headerRows) {
     csvStringResult += headerRow.join(columnDivider);
+    csvStringResult += lineDivider;
   }
   csvStringResult += cols.join(columnDivider);
   csvStringResult += lineDivider;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -113,7 +113,6 @@ function convertArrayOfObjectsToCSV(records, columns) {
   // in the keys valirable store fields API Names as a key
   // this labels use in CSV file header
   columns.forEach(col => {
-    console.log('col: ', col);
     if (col.fieldName) {
       if (col.fieldName === 'ProductLink') {
         keys.push(col.typeAttributes.label.fieldName);
@@ -124,6 +123,8 @@ function convertArrayOfObjectsToCSV(records, columns) {
       }
     }
   });
+  console.log('keys: ', keys);
+  console.log('cols: ', cols);
   csvStringResult = '';
   csvStringResult += cols.join(columnDivider);
   csvStringResult += lineDivider;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -133,7 +133,6 @@ function convertArrayOfObjectsToCSV(
   }
   csvStringResult += cols.join(columnDivider);
   csvStringResult += lineDivider;
-  console.log('records: ', records);
   for (let i = 0; i < records.length; i++) {
     counter = 0;
     // eslint-disable-next-line guard-for-in

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -138,7 +138,7 @@ function convertArrayOfObjectsToCSV(
     // eslint-disable-next-line guard-for-in
     for (let sTempkey in keys) {
       let skey = keys[sTempkey];
-      console.log('skey: ', skey);
+      skey = skey === 'Record ID' ? 'Record_ID' : skey;
       // add , [comma] after every String value,. [except first]
       if (counter > 0) {
         csvStringResult += columnDivider;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -33,12 +33,10 @@ async function LegacyExportPIM(req) {
     return 'Error - no session id';
   }
 
-  let daDownloadDetailsList, recordsAndCols;
+  let daDownloadDetailsList, recordsAndCols, templateAdditionalHeaders;
   try {
-    ({ daDownloadDetailsList, recordsAndCols } = await new PimStructure().build(
-      reqBody,
-      isListPageExport
-    ));
+    ({ daDownloadDetailsList, recordsAndCols, templateAdditionalHeaders } =
+      await new PimStructure().build(reqBody, isListPageExport));
   } catch (err) {
     console.log('error: ', err);
   }
@@ -61,7 +59,8 @@ async function LegacyExportPIM(req) {
 
   let csvString = convertArrayOfObjectsToCSV(
     recordsAndCols[0],
-    recordsAndCols[1]
+    recordsAndCols[1],
+    templateAdditionalHeaders
   );
   if (csvString == null) {
     logErrorResponse('csvString is empty!', '[ExportPIM]');
@@ -93,7 +92,11 @@ async function LegacyExportPIM(req) {
   return csvString;
 }
 
-function convertArrayOfObjectsToCSV(records, columns) {
+function convertArrayOfObjectsToCSV(
+  records,
+  columns,
+  templateAdditionalHeaders
+) {
   let csvStringResult,
     counter,
     keys = [],
@@ -126,11 +129,7 @@ function convertArrayOfObjectsToCSV(records, columns) {
   console.log('keys: ', keys);
   console.log('cols: ', cols);
   csvStringResult = '';
-  const headerRows = [
-    ['bla1', 'bla2'],
-    ['bla11', 'bla22']
-  ];
-  for (let headerRow of headerRows) {
+  for (let headerRow of templateAdditionalHeaders) {
     csvStringResult += headerRow.join(columnDivider);
     csvStringResult += lineDivider;
   }

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -27,9 +27,11 @@ async function LegacyExportPIM(req) {
     isTest: reqBody.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY,
     user: reqBody.user
-  })
+  });
   reqBody.sessionId = response.access_token;
-  if (!reqBody.sessionId) { return 'Error - no session id'; }
+  if (!reqBody.sessionId) {
+    return 'Error - no session id';
+  }
 
   let daDownloadDetailsList, recordsAndCols;
   try {
@@ -111,6 +113,7 @@ function convertArrayOfObjectsToCSV(records, columns) {
   // in the keys valirable store fields API Names as a key
   // this labels use in CSV file header
   columns.forEach(col => {
+    console.log('col: ', col);
     if (col.fieldName) {
       if (col.fieldName === 'ProductLink') {
         keys.push(col.typeAttributes.label.fieldName);

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -138,6 +138,7 @@ function convertArrayOfObjectsToCSV(
     // eslint-disable-next-line guard-for-in
     for (let sTempkey in keys) {
       let skey = keys[sTempkey];
+      console.log('skey: ', skey);
       // add , [comma] after every String value,. [except first]
       if (counter > 0) {
         csvStringResult += columnDivider;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -126,6 +126,10 @@ function convertArrayOfObjectsToCSV(records, columns) {
   console.log('keys: ', keys);
   console.log('cols: ', cols);
   csvStringResult = '';
+  const headerRows = ['bla1, bla2'];
+  for (let headerRow of headerRows) {
+    csvStringResult += headerRow.join(columnDivider);
+  }
   csvStringResult += cols.join(columnDivider);
   csvStringResult += lineDivider;
   for (let i = 0; i < records.length; i++) {

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -126,7 +126,10 @@ function convertArrayOfObjectsToCSV(records, columns) {
   console.log('keys: ', keys);
   console.log('cols: ', cols);
   csvStringResult = '';
-  const headerRows = ['bla1, bla2'];
+  const headerRows = [
+    ['bla1', 'bla2'],
+    ['bla11', 'bla22']
+  ];
   for (let headerRow of headerRows) {
     csvStringResult += headerRow.join(columnDivider);
   }

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -133,6 +133,7 @@ function convertArrayOfObjectsToCSV(
   }
   csvStringResult += cols.join(columnDivider);
   csvStringResult += lineDivider;
+  console.log('records: ', records);
   for (let i = 0; i < records.length; i++) {
     counter = 0;
     // eslint-disable-next-line guard-for-in

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -126,8 +126,6 @@ function convertArrayOfObjectsToCSV(
       }
     }
   });
-  console.log('keys: ', keys);
-  console.log('cols: ', cols);
   csvStringResult = '';
   for (let headerRow of templateAdditionalHeaders) {
     csvStringResult += headerRow.join(columnDivider);

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -139,7 +139,6 @@ function convertArrayOfObjectsToCSV(
     // eslint-disable-next-line guard-for-in
     for (let sTempkey in keys) {
       let skey = keys[sTempkey];
-      skey = skey === 'Record ID' ? 'Record_ID' : skey;
       // add , [comma] after every String value,. [except first]
       if (counter > 0) {
         csvStringResult += columnDivider;

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -738,8 +738,12 @@ async function addExportColumns(
               });
             } else if (count === numOfColumnAttributes) {
               // Invalid attribute field
+              templateHeaderValueMap.set(
+                templateHeaders[lastHeaderRowIndex][i],
+                '<Invalid Attribute>'
+              );
               exportColumns.push({
-                fieldName: '<Invalid Attribute>',
+                fieldName: templateHeaders[lastHeaderRowIndex][i],
                 label: templateHeaders[lastHeaderRowIndex][i],
                 type: 'text'
               });

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -190,7 +190,8 @@ async function PimRecordListHelper(
       exportRecordsAndColumns,
       DEFAULT_COLUMNS,
       isProduct
-    )
+    ),
+    templateAdditionalHeaders: []
   };
 }
 
@@ -708,6 +709,7 @@ async function addExportColumns(
       let isAttributeField;
       let isDefaultColumn;
       const defaultColumnNames = Array.from(defaultColumns.keys());
+      const lastHeaderRowIndex = templateHeaders.length - 1;
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
         isAttributeField = field.includes(ATTRIBUTE_FLAG);
@@ -717,7 +719,7 @@ async function addExportColumns(
           field = field.slice(11, -1);
           exportColumns.push({
             fieldName: defaultColumns.get(field),
-            label: templateHeaders[i],
+            label: templateHeaders[lastHeaderRowIndex][i],
             type: 'text'
           });
         } else if (isAttributeField && !isDefaultColumn) {
@@ -727,17 +729,20 @@ async function addExportColumns(
             if (helper.getValue(colAttr, 'Label__c') === field) {
               exportColumns.push({
                 fieldName: helper.getValue(colAttr, 'Primary_Key__c'),
-                label: templateHeaders[i],
+                label: templateHeaders[lastHeaderRowIndex][i],
                 type: 'text'
               });
             }
           });
         } else if (!isAttributeField) {
           // col's value specified in template is a raw value
-          templateHeaderValueMap.set(templateHeaders[i], field);
+          templateHeaderValueMap.set(
+            templateHeaders[lastHeaderRowIndex][i],
+            field
+          );
           exportColumns.push({
-            fieldName: templateHeaders[i],
-            label: templateHeaders[i],
+            fieldName: templateHeaders[lastHeaderRowIndex][i],
+            label: templateHeaders[lastHeaderRowIndex][i],
             type: 'text'
           });
         }

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -710,6 +710,8 @@ async function addExportColumns(
       let isDefaultColumn;
       const defaultColumnNames = Array.from(defaultColumns.keys());
       const lastHeaderRowIndex = templateHeaders.length - 1;
+      const numOfColumnAttributes = columnAttributes.length;
+      let count;
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
         isAttributeField = field.includes(ATTRIBUTE_FLAG);
@@ -725,10 +727,19 @@ async function addExportColumns(
         } else if (isAttributeField && !isDefaultColumn) {
           // value specified in template is a field's value, and col in template is an attribute column
           field = field.slice(11, -1);
+          count = 0;
           columnAttributes.forEach(colAttr => {
+            count++;
             if (helper.getValue(colAttr, 'Label__c') === field) {
               exportColumns.push({
                 fieldName: helper.getValue(colAttr, 'Primary_Key__c'),
+                label: templateHeaders[lastHeaderRowIndex][i],
+                type: 'text'
+              });
+            } else if (count === numOfColumnAttributes) {
+              // Invalid attribute field
+              exportColumns.push({
+                fieldName: '<Invalid Attribute>',
                 label: templateHeaders[lastHeaderRowIndex][i],
                 type: 'text'
               });

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -742,7 +742,7 @@ async function addExportColumns(
               // Invalid attribute field
               templateHeaderValueMap.set(
                 templateHeaders[lastHeaderRowIndex][i],
-                '<Invalid Attribute>'
+                ''
               );
               exportColumns.push({
                 fieldName: templateHeaders[lastHeaderRowIndex][i],

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -711,7 +711,7 @@ async function addExportColumns(
       const defaultColumnNames = Array.from(defaultColumns.keys());
       const lastHeaderRowIndex = templateHeaders.length - 1;
       const numOfColumnAttributes = columnAttributes.length;
-      let count;
+      let missedCount;
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
         isAttributeField = field.includes(ATTRIBUTE_FLAG);
@@ -727,16 +727,18 @@ async function addExportColumns(
         } else if (isAttributeField && !isDefaultColumn) {
           // value specified in template is a field's value, and col in template is an attribute column
           field = field.slice(11, -1);
-          count = 0;
-          columnAttributes.forEach(colAttr => {
-            count++;
+          missedCount = 0;
+          for (let colAttr of columnAttributes) {
             if (helper.getValue(colAttr, 'Label__c') === field) {
               exportColumns.push({
                 fieldName: helper.getValue(colAttr, 'Primary_Key__c'),
                 label: templateHeaders[lastHeaderRowIndex][i],
                 type: 'text'
               });
-            } else if (count === numOfColumnAttributes) {
+              break;
+            }
+            missedCount++;
+            if (missedCount === numOfColumnAttributes - 1) {
               // Invalid attribute field
               templateHeaderValueMap.set(
                 templateHeaders[lastHeaderRowIndex][i],
@@ -748,7 +750,7 @@ async function addExportColumns(
                 type: 'text'
               });
             }
-          });
+          }
         } else if (!isAttributeField) {
           // col's value specified in template is a raw value
           templateHeaderValueMap.set(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -890,14 +890,33 @@ class PimStructure {
     if (!templateVersionData) return { templateFields, templateHeaders };
 
     const templateRows = templateVersionData.split(/\r?\n/);
-    templateHeaders = templateRows?.[0]?.split(',') || [];
-    templateFields = templateRows?.[1]?.split(',') || [];
-    return {
-      templateFields: templateFields
-        .filter(field => field.includes(ATTRIBUTE_FLAG))
-        .map(attrField => removeDoubleQuotes(attrField)),
-      templateHeaders
+    let isDataRow = false;
+    let templateHeadersAndFields = {
+      templateFields: [],
+      templateHeaders: []
     };
+    for (let row of templateRows) {
+      if (row.includes(ATTRIBUTE_FLAG)) {
+        isDataRow = true;
+        templateHeadersAndFields.templateFields = row
+          .split(',')
+          .filter(field => field.includes(ATTRIBUTE_FLAG))
+          .map(attrField => removeDoubleQuotes(attrField));
+        break;
+      }
+      templateHeadersAndFields.templateHeaders.push(row.split(','));
+    }
+    // templateHeaders = templateRows?.[0]?.split(',') || [];
+    // templateFields = templateRows?.[1]?.split(',') || [];
+    // return {
+    //   templateFields: templateFields
+    //     .filter(field => field.includes(ATTRIBUTE_FLAG))
+    //     .map(attrField => removeDoubleQuotes(attrField)),
+    //   templateHeaders
+    // };
+    console.log('templateHeaders: ', templateHeadersAndFields.templateHeaders);
+    console.log('templateFields: ', templateHeadersAndFields.templateFields);
+    return templateHeadersAndFields;
   }
 }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -900,7 +900,6 @@ class PimStructure {
         isDataRow = true;
         templateHeadersAndFields.templateFields = row
           .split(',')
-          .filter(field => field.includes(ATTRIBUTE_FLAG))
           .map(attrField => removeDoubleQuotes(attrField));
         break;
       }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -823,6 +823,20 @@ class PimStructure {
                   type: 'text'
                 }
               ];
+            } else {
+              // field name specified does not exist, treat as raw value
+              templateHeaderValueMap.set(
+                templateHeaders[lastHeaderRowIndex][i],
+                field
+              );
+              exportColumns = [
+                ...exportColumns,
+                {
+                  fieldName: templateHeaders[lastHeaderRowIndex][i],
+                  label: templateHeaders[lastHeaderRowIndex][i],
+                  type: 'text'
+                }
+              ];
             }
           });
         } else {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -820,6 +820,8 @@ class PimStructure {
           });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
+          console.log('templateHeader: ', templateHeaders[i]);
+          console.log('field: ', field);
           templateHeaderValueMap.set(templateHeaders[i], field);
           exportColumns = [
             ...exportColumns,
@@ -913,8 +915,6 @@ class PimStructure {
     //     .map(attrField => removeDoubleQuotes(attrField)),
     //   templateHeaders
     // };
-    console.log('templateHeaders: ', templateHeadersAndFields.templateHeaders);
-    console.log('templateFields: ', templateHeadersAndFields.templateFields);
     return templateHeadersAndFields;
   }
 }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -808,11 +808,6 @@ class PimStructure {
       // clean up data for easier parsing
       const supportedAttributes = productVariantValueMapList[0];
       supportedAttributes.delete(ID_FIELD);
-      // supportedAttributes.set(
-      //   RECORD_ID_LABEL,
-      //   supportedAttributes.get(RECORD_ID_FIELD)
-      // );
-      // supportedAttributes.delete(RECORD_ID_FIELD);
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
@@ -838,7 +833,7 @@ class PimStructure {
             // invalid attribute name provided
             templateHeaderValueMap.set(
               templateHeaders[lastHeaderRowIndex][i],
-              'Invalid Attribute'
+              '<Invalid Attribute>'
             );
             exportColumns = [
               ...exportColumns,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -808,11 +808,11 @@ class PimStructure {
       // clean up data for easier parsing
       const supportedAttributes = productVariantValueMapList[0];
       supportedAttributes.delete(ID_FIELD);
-      supportedAttributes.set(
-        RECORD_ID_LABEL,
-        supportedAttributes.get(RECORD_ID_FIELD)
-      );
-      supportedAttributes.delete(RECORD_ID_FIELD);
+      // supportedAttributes.set(
+      //   RECORD_ID_LABEL,
+      //   supportedAttributes.get(RECORD_ID_FIELD)
+      // );
+      // supportedAttributes.delete(RECORD_ID_FIELD);
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
@@ -820,7 +820,11 @@ class PimStructure {
         if (field.includes(ATTRIBUTE_FLAG)) {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
-          if (supportedAttributes.has(field)) {
+          if (
+            (field !== RECORD_ID_LABEL && supportedAttributes.has(field)) ||
+            (field === RECORD_ID_LABEL &&
+              supportedAttributes.has(RECORD_ID_FIELD))
+          ) {
             // push columns specified in template
             exportColumns = [
               ...exportColumns,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -831,10 +831,10 @@ class PimStructure {
               }
             ];
           } else {
-            // invalid attribute name provided, the field will be considered as a raw value
+            // invalid attribute name provided
             templateHeaderValueMap.set(
               templateHeaders[lastHeaderRowIndex][i],
-              field
+              'Invalid Attribute'
             );
             exportColumns = [
               ...exportColumns,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -809,25 +809,32 @@ class PimStructure {
         if (field.includes(ATTRIBUTE_FLAG)) {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
-          Array.from(productVariantValueMapList[0].keys()).forEach(col => {
-            const isMatchingColAndField =
-              (field !== 'Record ID' && field === col) ||
-              (col === 'Record_ID' && field === 'Record ID');
-            if (col !== 'Id' && isMatchingColAndField) {
-              // push columns specified in template
-              console.log('field1: ', field);
-              exportColumns = [
-                ...exportColumns,
-                {
-                  fieldName: col,
-                  label: templateHeaders[lastHeaderRowIndex][i],
-                  type: 'text'
-                }
-              ];
-            } else {
-              console.log('field2: ', field);
-            }
-          });
+          if (productVariantValueMapList[0].has(field)) {
+            console.log('yes');
+          }
+          console.log(
+            'Array.from(productVariantValueMapList[0].keys()): ',
+            Array.from(productVariantValueMapList[0].keys())
+          );
+          // Array.from(productVariantValueMapList[0].keys()).forEach(col => {
+          //   const isMatchingColAndField =
+          //     (field !== 'Record ID' && field === col) ||
+          //     (col === 'Record_ID' && field === 'Record ID');
+          //   if (col !== 'Id' && isMatchingColAndField) {
+          //     // push columns specified in template
+          //     console.log('field1: ', field);
+          //     exportColumns = [
+          //       ...exportColumns,
+          //       {
+          //         fieldName: col,
+          //         label: templateHeaders[lastHeaderRowIndex][i],
+          //         type: 'text'
+          //       }
+          //     ];
+          //   } else {
+          //     console.log('field2: ', field);
+          //   }
+          // });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
           console.log('field3: ', field);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -827,15 +827,6 @@ class PimStructure {
           });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
-          console.log(
-            'templateHeader: ',
-            templateHeaders[lastHeaderRowIndex][i]
-          );
-          console.log('field: ', field);
-          templateHeaderValueMap.set(
-            templateHeaders[lastHeaderRowIndex][i],
-            field
-          );
           exportColumns = [
             ...exportColumns,
             {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -453,11 +453,8 @@ class PimStructure {
     }
     if (templateHeaders.length > 1) {
       // template has more than 1 header row
-      exportRecordsColsAndAssets.templateAdditionalHeaders =
-        templateHeaders.splice(
-          templateHeaders.length - 1,
-          templateHeaders.length
-        );
+      templateHeaders.pop();
+      exportRecordsColsAndAssets.templateAdditionalHeaders = templateHeaders;
     }
     return exportRecordsColsAndAssets;
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -439,7 +439,8 @@ class PimStructure {
           templateFields,
           templateHeaders,
           exportRecordsAndColumns
-        )
+        ),
+        templateAdditionalHeaders: []
       };
       Object.assign(asposeInput, {
         detailPageData: exportRecordsColsAndAssets?.recordsAndCols[0],
@@ -449,6 +450,14 @@ class PimStructure {
     if (useAspose) {
       await callAsposeToExport(asposeInput);
       return { daDownloadDetailsList };
+    }
+    if (templateHeaders.length > 1) {
+      // template has more than 1 header row
+      exportRecordsColsAndAssets.templateAdditionalHeaders =
+        templateHeaders.splice(
+          templateHeaders.length - 1,
+          templateHeaders.length
+        );
     }
     return exportRecordsColsAndAssets;
   }
@@ -783,7 +792,6 @@ class PimStructure {
   ) {
     let exportColumns = [];
     let templateHeaderValueMap = new Map();
-    const lastHeaderRowIndex = templateHeaders.length - 1;
     if (!templateFields || templateFields.length === 0) {
       // if not template export, push all attribute columns except sobject id and rename Category__r.Name to Category
       exportColumns = Array.from(productVariantValueMapList[0].keys())
@@ -796,6 +804,7 @@ class PimStructure {
         });
     } else if (templateFields && templateFields.length > 0) {
       // template export
+      const lastHeaderRowIndex = templateHeaders.length - 1;
       let field;
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -783,6 +783,7 @@ class PimStructure {
   ) {
     let exportColumns = [];
     let templateHeaderValueMap = new Map();
+    const lastHeaderRowIndex = templateHeaders.length - 1;
     if (!templateFields || templateFields.length === 0) {
       // if not template export, push all attribute columns except sobject id and rename Category__r.Name to Category
       exportColumns = Array.from(productVariantValueMapList[0].keys())
@@ -812,7 +813,7 @@ class PimStructure {
                 ...exportColumns,
                 {
                   fieldName: col,
-                  label: templateHeaders[i],
+                  label: templateHeaders[lastHeaderRowIndex - 1][i],
                   type: 'text'
                 }
               ];
@@ -820,14 +821,20 @@ class PimStructure {
           });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
-          console.log('templateHeader: ', templateHeaders[i]);
+          console.log(
+            'templateHeader: ',
+            templateHeaders[lastHeaderRowIndex - 1][i]
+          );
           console.log('field: ', field);
-          templateHeaderValueMap.set(templateHeaders[i], field);
+          templateHeaderValueMap.set(
+            templateHeaders[lastHeaderRowIndex - 1][i],
+            field
+          );
           exportColumns = [
             ...exportColumns,
             {
-              fieldName: templateHeaders[i],
-              label: templateHeaders[i],
+              fieldName: templateHeaders[lastHeaderRowIndex - 1][i],
+              label: templateHeaders[lastHeaderRowIndex - 1][i],
               type: 'text'
             }
           ];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -813,7 +813,7 @@ class PimStructure {
         supportedAttributes.get(RECORD_ID_FIELD)
       );
       supportedAttributes.delete(RECORD_ID_FIELD);
-
+      console.log('templateFields.length: ', templateFields.length);
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -833,7 +833,7 @@ class PimStructure {
             // invalid attribute name provided
             templateHeaderValueMap.set(
               templateHeaders[lastHeaderRowIndex][i],
-              '<Invalid Attribute>'
+              ''
             );
             exportColumns = [
               ...exportColumns,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -815,6 +815,7 @@ class PimStructure {
               (col === 'Record_ID' && field === 'Record ID');
             if (col !== 'Id' && isMatchingColAndField) {
               // push columns specified in template
+              console.log('field1: ', field);
               exportColumns = [
                 ...exportColumns,
                 {
@@ -824,23 +825,12 @@ class PimStructure {
                 }
               ];
             } else {
-              // field name specified does not exist, treat as raw value
-              templateHeaderValueMap.set(
-                templateHeaders[lastHeaderRowIndex][i],
-                field
-              );
-              exportColumns = [
-                ...exportColumns,
-                {
-                  fieldName: templateHeaders[lastHeaderRowIndex][i],
-                  label: templateHeaders[lastHeaderRowIndex][i],
-                  type: 'text'
-                }
-              ];
+              console.log('field2: ', field);
             }
           });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
+          console.log('field3: ', field);
           templateHeaderValueMap.set(
             templateHeaders[lastHeaderRowIndex][i],
             field

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -820,7 +820,9 @@ class PimStructure {
         if (field.includes(ATTRIBUTE_FLAG)) {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
+          console.log('field: ', field);
           if (supportedAttributes.has(field)) {
+            console.log('1');
             // push columns specified in template
             exportColumns = [
               ...exportColumns,
@@ -831,6 +833,7 @@ class PimStructure {
               }
             ];
           } else {
+            console.log('2');
             // invalid attribute name provided
             templateHeaderValueMap.set(
               templateHeaders[lastHeaderRowIndex][i],
@@ -846,6 +849,7 @@ class PimStructure {
             ];
           }
         } else {
+          console.log('3');
           // template specifies that the column's rows should contain the raw value in the template
           templateHeaderValueMap.set(
             templateHeaders[lastHeaderRowIndex][i],

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -821,32 +821,32 @@ class PimStructure {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
           if (supportedAttributes.has(field)) {
-            console.log('yes');
+            // push columns specified in template
+            exportColumns = [
+              ...exportColumns,
+              {
+                fieldName: col,
+                label: templateHeaders[lastHeaderRowIndex][i],
+                type: 'text'
+              }
+            ];
           } else {
-            console.log(field);
+            // invalid attribute name provided, the field will be considered as a raw value
+            templateHeaderValueMap.set(
+              templateHeaders[lastHeaderRowIndex][i],
+              field
+            );
+            exportColumns = [
+              ...exportColumns,
+              {
+                fieldName: templateHeaders[lastHeaderRowIndex][i],
+                label: templateHeaders[lastHeaderRowIndex][i],
+                type: 'text'
+              }
+            ];
           }
-          // Array.from(productVariantValueMapList[0].keys()).forEach(col => {
-          //   const isMatchingColAndField =
-          //     (field !== 'Record ID' && field === col) ||
-          //     (col === 'Record_ID' && field === 'Record ID');
-          //   if (col !== 'Id' && isMatchingColAndField) {
-          //     // push columns specified in template
-          //     console.log('field1: ', field);
-          //     exportColumns = [
-          //       ...exportColumns,
-          //       {
-          //         fieldName: col,
-          //         label: templateHeaders[lastHeaderRowIndex][i],
-          //         type: 'text'
-          //       }
-          //     ];
-          //   } else {
-          //     console.log('field2: ', field);
-          //   }
-          // });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
-          console.log('field3: ', field);
           templateHeaderValueMap.set(
             templateHeaders[lastHeaderRowIndex][i],
             field

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -813,7 +813,7 @@ class PimStructure {
                 ...exportColumns,
                 {
                   fieldName: col,
-                  label: templateHeaders[lastHeaderRowIndex - 1][i],
+                  label: templateHeaders[lastHeaderRowIndex][i],
                   type: 'text'
                 }
               ];
@@ -823,18 +823,18 @@ class PimStructure {
           // template specifies that the column's rows should contain the raw value in the template
           console.log(
             'templateHeader: ',
-            templateHeaders[lastHeaderRowIndex - 1][i]
+            templateHeaders[lastHeaderRowIndex][i]
           );
           console.log('field: ', field);
           templateHeaderValueMap.set(
-            templateHeaders[lastHeaderRowIndex - 1][i],
+            templateHeaders[lastHeaderRowIndex][i],
             field
           );
           exportColumns = [
             ...exportColumns,
             {
-              fieldName: templateHeaders[lastHeaderRowIndex - 1][i],
-              label: templateHeaders[lastHeaderRowIndex - 1][i],
+              fieldName: templateHeaders[lastHeaderRowIndex][i],
+              label: templateHeaders[lastHeaderRowIndex][i],
               type: 'text'
             }
           ];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -827,6 +827,10 @@ class PimStructure {
           });
         } else {
           // template specifies that the column's rows should contain the raw value in the template
+          templateHeaderValueMap.set(
+            templateHeaders[lastHeaderRowIndex][i],
+            field
+          );
           exportColumns = [
             ...exportColumns,
             {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -813,16 +813,14 @@ class PimStructure {
         supportedAttributes.get(RECORD_ID_FIELD)
       );
       supportedAttributes.delete(RECORD_ID_FIELD);
-      console.log('templateFields.length: ', templateFields.length);
+
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
 
         if (field.includes(ATTRIBUTE_FLAG)) {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
-          console.log('field: ', field);
           if (supportedAttributes.has(field)) {
-            console.log('1');
             // push columns specified in template
             exportColumns = [
               ...exportColumns,
@@ -833,7 +831,6 @@ class PimStructure {
               }
             ];
           } else {
-            console.log('2');
             // invalid attribute name provided
             templateHeaderValueMap.set(
               templateHeaders[lastHeaderRowIndex][i],
@@ -849,7 +846,6 @@ class PimStructure {
             ];
           }
         } else {
-          console.log('3');
           // template specifies that the column's rows should contain the raw value in the template
           templateHeaderValueMap.set(
             templateHeaders[lastHeaderRowIndex][i],

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -23,6 +23,8 @@ const CATEGORY_NAME_LABEL = 'Category';
 const DA_TYPE = 'DigitalAsset';
 const ID_FIELD = 'Id';
 const PRODUCT_REFERENCE_TYPE = 'ProductReference';
+const RECORD_ID_FIELD = 'Record_ID';
+const RECORD_ID_LABEL = 'Record ID';
 
 class PimStructure {
   constructor() {}
@@ -803,19 +805,26 @@ class PimStructure {
       // template export
       const lastHeaderRowIndex = templateHeaders.length - 1;
       let field;
+      // clean up data for easier parsing
+      const supportedAttributes = productVariantValueMapList[0];
+      supportedAttributes.delete(ID_FIELD);
+      supportedAttributes.set(
+        RECORD_ID_LABEL,
+        supportedAttributes.get(RECORD_ID_FIELD)
+      );
+      supportedAttributes.delete(RECORD_ID_FIELD);
+
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
 
         if (field.includes(ATTRIBUTE_FLAG)) {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
-          if (productVariantValueMapList[0].has(field)) {
+          if (supportedAttributes.has(field)) {
             console.log('yes');
+          } else {
+            console.log(field);
           }
-          console.log(
-            'Array.from(productVariantValueMapList[0].keys()): ',
-            Array.from(productVariantValueMapList[0].keys())
-          );
           // Array.from(productVariantValueMapList[0].keys()).forEach(col => {
           //   const isMatchingColAndField =
           //     (field !== 'Record ID' && field === col) ||

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -452,7 +452,7 @@ class PimStructure {
       return { daDownloadDetailsList };
     }
     if (templateHeaders.length > 1) {
-      // template has more than 1 header row
+      // template has more than 1 header row, pop the last header row as it is already tied to the data row
       templateHeaders.pop();
       exportRecordsColsAndAssets.templateAdditionalHeaders = templateHeaders;
     }
@@ -911,14 +911,6 @@ class PimStructure {
       }
       templateHeadersAndFields.templateHeaders.push(row.split(','));
     }
-    // templateHeaders = templateRows?.[0]?.split(',') || [];
-    // templateFields = templateRows?.[1]?.split(',') || [];
-    // return {
-    //   templateFields: templateFields
-    //     .filter(field => field.includes(ATTRIBUTE_FLAG))
-    //     .map(attrField => removeDoubleQuotes(attrField)),
-    //   templateHeaders
-    // };
     return templateHeadersAndFields;
   }
 }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -825,7 +825,7 @@ class PimStructure {
             exportColumns = [
               ...exportColumns,
               {
-                fieldName: col,
+                fieldName: field,
                 label: templateHeaders[lastHeaderRowIndex][i],
                 type: 'text'
               }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -829,7 +829,7 @@ class PimStructure {
             exportColumns = [
               ...exportColumns,
               {
-                fieldName: field,
+                fieldName: field === RECORD_ID_LABEL ? RECORD_ID_FIELD : field,
                 label: templateHeaders[lastHeaderRowIndex][i],
                 type: 'text'
               }

--- a/test/PimStructure.test.js
+++ b/test/PimStructure.test.js
@@ -19,7 +19,7 @@ describe('PimStructure tests', () => {
       // array checks
       assert.typeOf(templateHeaders, 'array');
       assert.typeOf(templateFields, 'array');
-      assert.equal(templateHeaders.length, 2);
+      assert.equal(templateHeaders.length, 1);
       assert.equal(templateFields.length, 2);
 
       // value checks

--- a/test/PimStructure.test.js
+++ b/test/PimStructure.test.js
@@ -34,8 +34,9 @@ describe('PimStructure tests', () => {
         misconfiguredTemplatedExportCSVString
       );
 
-      // array checks
-      assert.equal(templateFields.length, 1);
+      // note that fields without PROPEL_ATT flag will be considered as raw values - which are valid fields and
+      // the expected behavior is that for every row in that column, the cell's value is the raw value
+      assert.equal(templateFields.length, 2);
       done();
     });
   });


### PR DESCRIPTION
https://github.com/PropelPLM/pim-data-service/assets/77341283/1c676d8f-82ba-4da4-8c7e-d811af823147
*Note a slight change after recording - removed the <Invalid Attribute> tag to standardize with xlsx

- added support for multiple header rows
- some refactoring to reduce time complexity
- fixed tests (`templateHeaders` is a list of lists in order to support multiple headers so length of `templateHeaders` in test file is 1 instead of 2)
- added edge case support for invalid attributes