### PR TITLE
PIM-985: PIM | Import | Break through current import limitations (Part 2)

### DIFF
--- a/lib/ImportProduct.js
+++ b/lib/ImportProduct.js
@@ -31,7 +31,7 @@ class ImportProduct extends ImportClass {
     this.productMap
     this.productNames
     this.variantValueMap
-    this.insertSliceSize = 500
+    this.insertSliceSize = 1000
 
     this.start()
   }

--- a/lib/ImportProduct.js
+++ b/lib/ImportProduct.js
@@ -31,6 +31,7 @@ class ImportProduct extends ImportClass {
     this.productMap
     this.productNames
     this.variantValueMap
+    this.insertSliceSize = 500
 
     this.start()
   }
@@ -172,7 +173,7 @@ class ImportProduct extends ImportClass {
     }
 
     if (insertProducts.length > 0) {
-      let results = await this.connection.insert(this.helper.namespace('Product__c'), insertProducts)
+      let results = await this.connection.insertSlice(this.helper.namespace('Product__c'), insertProducts, this.insertSliceSize)
       this.log.addToLogs(results, 'Product__c')
     }
   }
@@ -214,7 +215,7 @@ class ImportProduct extends ImportClass {
     }
 
     if (insertAttributes.length > 0) {
-      let results = await this.connection.insert(this.helper.namespace('Attribute_Value__c'), insertAttributes)
+      let results = await this.connection.insertSlice(this.helper.namespace('Attribute_Value__c'), insertAttributes, this.insertSliceSize)
       this.log.addToLogs(results, 'Attribute__c')
     }
 
@@ -250,7 +251,7 @@ class ImportProduct extends ImportClass {
     }
 
     if (insertVariants.length > 0) {
-      let results = await this.connection.insert(this.helper.namespace('Variant__c'), insertVariants)
+      let results = await this.connection.insertSlice(this.helper.namespace('Variant__c'), insertVariants, this.insertSliceSize)
       this.log.addToLogs(results, 'Variant__c')
     }
   }
@@ -294,7 +295,7 @@ class ImportProduct extends ImportClass {
     }
 
     if (insertVariantValues.length > 0) {
-      let results = await this.connection.insert(this.helper.namespace('Variant_Value__c'), insertVariantValues)
+      let results = await this.connection.insertSlice(this.helper.namespace('Variant_Value__c'), insertVariantValues, this.insertSliceSize)
       this.log.addToLogs(results, 'Variant_Value__c')
     }
   }
@@ -371,7 +372,7 @@ class ImportProduct extends ImportClass {
     }
 
     if (insertAttributes.length > 0) {
-      let results = await this.connection.insert(this.helper.namespace('Attribute_Value__c'), insertAttributes)
+      let results = await this.connection.insertSlice(this.helper.namespace('Attribute_Value__c'), insertAttributes, this.insertSliceSize)
       this.log.addToLogs(
         results,
         'Attribute_Value__c'

--- a/service/PimVariantValue.js
+++ b/service/PimVariantValue.js
@@ -16,7 +16,7 @@ class PimVariantValue {
     try {
       this.variantValues = await this.helper.connection.queryExtend(this.helper.namespaceQuery(
         `select Id, Name from Variant_Value__c where Name in (${this.helper.connection.QUERY_LIST})`
-      ), this.variantNames)
+      ), Array.from(new Set(this.variantNames)))
     } catch(error) {
       this.log.addToLogs([{errors: [error] }], this.helper.namespace('Variant_Value__c'))
 


### PR DESCRIPTION
- prevents Variant_Value duplicate query
- change insert to `insertSlice` with size 500 to break limits. (insert have 10k row limits)