### PR TITLE
PIM-917-2: PIM | Export | Current Record export type should only export that records digital asset

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -232,9 +232,6 @@ class PimStructure {
                     overwrittenValues[j],
                     'Overwritten_Variant_Value__c'
                   );
-                  console.log(
-                    valuesList[i][0].Id + ', ' + affectedVariantValue
-                  );
                   if (valuesList[i][0].Id !== affectedVariantValue) {
                     // skip attribute values which are not overwriting the current variant value
                     continue;

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -50,7 +50,7 @@ class PimStructure {
       daDownloadDetailsList = [],
       productVariantsDaDetailsMap,
       nonEmptyProductDaAttrLabelsIds = [],
-      variantValueHierarchyMap;
+      variantValueHierarchyMap = new Map();
     if (reqBody.options.isTemplateExport) {
       if (reqBody.templateVersionData) {
         ({ templateFields, templateHeaders } = this.getTemplateHeadersAndFields(
@@ -603,7 +603,6 @@ class PimStructure {
     variantValueHierarchyMap,
     productId
   ) {
-    variantValueHierarchyMap = new Map();
     for (let vv of valuesList) {
       const parentVariantValueId = helper.getValue(
         vv[0],
@@ -617,6 +616,7 @@ class PimStructure {
       }
     }
     console.log('variantValueHierarchyMap1: ', variantValueHierarchyMap);
+    return variantValueHierarchyMap;
   }
 
   async fillInInheritedData(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -232,6 +232,9 @@ class PimStructure {
                     overwrittenValues[j],
                     'Overwritten_Variant_Value__c'
                   );
+                  console.log(
+                    valuesList[i][0].Id + ', ' + affectedVariantValue
+                  );
                   if (valuesList[i][0].Id !== affectedVariantValue) {
                     // skip attribute values which are not overwriting the current variant value
                     continue;
@@ -907,6 +910,10 @@ class PimStructure {
   ) {
     // Option 1: Check if is inherited
     if (isInherited) {
+      console.log(
+        'productVariantsDaDetailsMap FINAL: ',
+        productVariantsDaDetailsMap
+      );
       // iterate over digital asset attribute labels which the base product has digital assets for
       let currRecordId;
       for (let labelId of nonEmptyProductDaAttrLabelsIds) {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -756,12 +756,12 @@ class PimStructure {
               newValue = await parseProductReferenceAttrVal(newValue, reqBody);
             }
             // update the newVariant object with the overwritten values
-            console.log('affectedLabelname: ', affectedLabelName);
             newVariant.set(affectedLabelName, newValue);
           }
         }
         exportRecords.push(newVariant);
       }
+      console.log('exportRecords1: ', exportRecords);
       exportType = 'currentVariant';
     } else if (exportType === 'lowestVariants') {
       lowestLevelVariantValues = await getLowestVariantValuesList(
@@ -815,7 +815,7 @@ class PimStructure {
           }
         });
       });
-
+    console.log('filledInExportRecord1: ', filledInExportRecords);
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
@@ -850,6 +850,7 @@ class PimStructure {
         });
       });
     });
+    console.log('filledInExportRecord2: ', filledInExportRecords);
     // remove base product from SKU export or current variant export (if current record is not base product)
     return (exportType === 'currentVariant' &&
       reqBody.variantValuePath.length > 0) ||

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -182,7 +182,10 @@ class PimStructure {
 
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
-            valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
+            // valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
+            Array.from(variantAndValueMap.values()).forEach(valList => {
+              valuesList.push.apply(valuesList, valList); // flatten array
+            });
             console.log('valList[1]: ', valuesList[1]);
             this.populateVariantValueHierarchyMap(
               valuesList,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -515,7 +515,7 @@ class PimStructure {
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
-          nonEmptyProductDaAttrLabelsIds,
+          appearingLabelIds,
           productVariantsDaDetailsMap,
           daDownloadDetailsList,
           variantValueHierarchyMap,
@@ -926,7 +926,7 @@ class PimStructure {
 
   async getFinalizedDaList(
     isInherited,
-    nonEmptyProductDaAttrLabelsIds,
+    appearingLabelIds,
     productVariantsDaDetailsMap,
     daDownloadDetailsList,
     variantValueHierarchyMap,
@@ -939,13 +939,13 @@ class PimStructure {
         'productVariantsDaDetailsMap FINAL: ',
         productVariantsDaDetailsMap
       );
-      // iterate over digital asset attribute labels which the base product has digital assets for
-      for (let labelId of nonEmptyProductDaAttrLabelsIds) {
+      // iterate over all attribute labels included in the export
+      for (let labelId of appearingLabelIds) {
         for (let record of exportRecords) {
           currRecordId = record.get('Id');
           while (true) {
             // check if variant value has digital asset for this label, if not iteratively search parent variant values
-            // until product is reached
+            // until product
             console.log('========================');
             console.log('currRecordId: ', currRecordId);
             console.log('labelId: ', labelId);
@@ -954,7 +954,7 @@ class PimStructure {
               ?.get(labelId);
             if (currRecordDigitalAsset) {
               console.log('record with DA: ', currRecordId);
-              // add prod/variant val's digital asset for list of assets for export, no need to search in parent
+              // add prod/variant val's digital asset for list of assets for export, move on to next label
               daDownloadDetailsList.push(currRecordDigitalAsset);
               break;
             } else {
@@ -967,9 +967,7 @@ class PimStructure {
               if (parentRecordId) {
                 currRecordId = parentRecordId;
               } else {
-                // only record that has no parent id should be product, which should have asset for this label (as we
-                // are only looping through labels where product has assets). Break is just to prevent infinite loop in
-                // event of bug
+                // none of the variant values and product have DA for this label, move on to next label
                 break;
               }
             }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -334,7 +334,7 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
-          this.populateVariantValueHierarchyMap(
+          await this.populateVariantValueHierarchyMap(
             valuesList,
             variantValueHierarchyMap,
             baseRecord.get('Id')
@@ -588,7 +588,7 @@ class PimStructure {
   }
 
   // creates a Map <Id, Id> with key value pairs being [variantValueId, parentVariantValueId] or [variantValueId, productId]
-  populateVariantValueHierarchyMap(
+  async populateVariantValueHierarchyMap(
     valuesList,
     variantValueHierarchyMap,
     productId
@@ -606,7 +606,6 @@ class PimStructure {
         variantValueHierarchyMap.set(vv[0].Id, productId);
       }
     }
-    console.log('variantValueHierarchyMap1: ', variantValueHierarchyMap);
   }
 
   async fillInInheritedData(
@@ -818,7 +817,10 @@ class PimStructure {
       });
     console.log('valuesList: ', valuesList);
     console.log('exportRecords: ', exportRecords);
-    this.updateExportRecordsWithVariantValueIds(valuesList, exportRecords);
+    await this.updateExportRecordsWithVariantValueIds(
+      valuesList,
+      exportRecords
+    );
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
       console.log('variant: ', variant);
@@ -909,7 +911,7 @@ class PimStructure {
     return childMap;
   }
 
-  updateExportRecordsWithVariantValueIds(valuesList, exportRecords) {
+  async updateExportRecordsWithVariantValueIds(valuesList, exportRecords) {
     let vvIdNameMap = new Map();
     console.log('vvId: ', valuesList[0].Id);
     console.log('vvName: ', valuesList[0].Name);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -943,8 +943,11 @@ class PimStructure {
     } else {
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
+        console.log('record: ', record);
         currRecordId = record.get('Id');
+        console.log('currRecordId 1: ', currRecordId);
         if (currRecordId) {
+          console.log('currRecordId 2: ', currRecordId);
           daDownloadDetailsList.push(
             Array.from(productVariantsDaDetailsMap.get(currRecordId)?.values())
           );

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -957,13 +957,15 @@ class PimStructure {
         }
       }
     }
-    await this.removeDuplicatedAssets(daDownloadDetailsList);
+    daDownloadDetailsList = await this.removeDuplicatedAssets(
+      daDownloadDetailsList
+    );
     console.log('daDownloadDetailsList: ', daDownloadDetailsList);
     return daDownloadDetailsList;
   }
 
   async removeDuplicatedAssets(daDownloadDetailsList) {
-    daDownloadDetailsList = daDownloadDetailsList.filter(
+    return daDownloadDetailsList.filter(
       (value, index, self) =>
         index ===
         self.findIndex(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -136,7 +136,6 @@ class PimStructure {
             //   helper,
             //   reqBody
             // );
-            console.log('1');
             attrValValue = await parseDaAttrValWithVarMap(
               baseRecord.get('Id'),
               digitalAssetMap,
@@ -166,10 +165,6 @@ class PimStructure {
           exportRecords[0].set(appearingLabels[i].Name, null);
         }
       }
-      console.log(
-        'productVariantsDaDetailsMap1: ',
-        productVariantsDaDetailsMap
-      );
       /** get product's appearing attribute labels end */
       if (isProduct) {
         let valuesList = [];
@@ -267,7 +262,6 @@ class PimStructure {
                     //   helper,
                     //   reqBody
                     // );
-                    console.log('2');
                     newValue = await parseDaAttrValWithVarMap(
                       valuesList[i][0].Id,
                       digitalAssetMap,
@@ -296,14 +290,9 @@ class PimStructure {
                 }
               }
             }
-            console.log(
-              'productVariantsDaDetailsMap2: ',
-              productVariantsDaDetailsMap
-            );
             currentVariantName = currentVariant.get('Record_ID');
             // overwrite base product with current variant
             exportRecords = [currentVariant];
-            console.log('currentVariant: ', currentVariant);
           }
         } else if (
           exportType === 'allVariants' ||
@@ -439,7 +428,6 @@ class PimStructure {
                   //   helper,
                   //   reqBody
                   // );
-                  console.log('3');
                   newValue = await parseDaAttrValWithVarMap(
                     valuesList[i].Id,
                     digitalAssetMap,
@@ -479,10 +467,6 @@ class PimStructure {
               exportRecords.push(newVariant);
             }
           }
-          console.log(
-            'productVariantsDaDetailsMap3: ',
-            productVariantsDaDetailsMap
-          );
         } else {
           throw 'Invalid Export Type';
         }
@@ -511,7 +495,6 @@ class PimStructure {
           exportRecordsAndColumns = [exportRecords];
         }
       }
-      console.log('exportRecordsAndColumns[0]: ', exportRecordsAndColumns[0]);
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
@@ -813,15 +796,12 @@ class PimStructure {
           }
         });
       });
-    console.log('valuesList: ', valuesList);
-    console.log('exportRecords: ', exportRecords);
     await this.updateExportRecordsWithVariantValueIds(
       valuesList,
       exportRecords
     );
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
-      console.log('variant: ', variant);
       // loop through each variant value's child variant values
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
         // find the child variant value's object in exportRecords
@@ -856,7 +836,6 @@ class PimStructure {
         });
       });
     });
-    console.log('filledInExportRecord2: ', filledInExportRecords);
     // remove base product from SKU export or current variant export (if current record is not base product)
     return (exportType === 'currentVariant' &&
       reqBody.variantValuePath.length > 0) ||
@@ -911,8 +890,6 @@ class PimStructure {
 
   async updateExportRecordsWithVariantValueIds(valuesList, exportRecords) {
     let vvIdNameMap = new Map();
-    console.log('vvId: ', valuesList[0].Id);
-    console.log('vvName: ', valuesList[0].Name);
     for (let variantValue of valuesList) {
       vvIdNameMap.set(variantValue.Name, variantValue.Id);
     }
@@ -941,6 +918,7 @@ class PimStructure {
       );
       // iterate over all attribute labels included in the export
       for (let labelId of appearingLabelIds) {
+        console.log('labelId: ', labelId);
         for (let record of exportRecords) {
           currRecordId = record.get('Id');
           while (true) {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -957,6 +957,10 @@ class PimStructure {
               break;
             } else {
               // variant val doesn't have DA for this attr label, search upwards for DA i.e. parent variant vals then product
+              console.log(
+                'variantValueHierarchyMap: ',
+                variantValueHierarchyMap
+              );
               const parentRecordId = variantValueHierarchyMap.get(currRecordId);
               if (parentRecordId) {
                 currRecordId = parentRecordId;

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -498,7 +498,7 @@ class PimStructure {
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
-          appearingLabelIds,
+          appearingLabelIds.split(', '),
           productVariantsDaDetailsMap,
           daDownloadDetailsList,
           variantValueHierarchyMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -94,13 +94,6 @@ class PimStructure {
         exportRecords = [baseRecord],
         exportRecordsAndColumns = [exportRecords],
         attrValValue;
-      // daDownloadDetailsList = initAssetDownloadDetailsList(
-      //   isProduct,
-      //   includeRecordAsset,
-      //   recordList.map(record => record.Id),
-      //   digitalAssetMap,
-      //   namespace
-      // );
 
       // Map<productId or vvId, Map<Attribute Label Id, DADownloadDetails object>>
       productVariantsDaDetailsMap = new Map();
@@ -127,13 +120,6 @@ class PimStructure {
             helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') ===
             DA_TYPE
           ) {
-            // attrValValue = await parseDigitalAssetAttrVal(
-            //   digitalAssetMap,
-            //   attrValValue,
-            //   daDownloadDetailsList,
-            //   helper,
-            //   reqBody
-            // );
             attrValValue = await parseDaAttrValWithVarMap(
               baseRecord.get('Id'),
               digitalAssetMap,
@@ -167,8 +153,6 @@ class PimStructure {
         if (exportType === 'currentVariant') {
           if (reqBody.variantValuePath.length > 0) {
             // exporting current variant value (base product not included in export)
-            // remove base product's digital assets that were previously added
-            // daDownloadDetailsList = [];
             const currentVariantId =
               reqBody.variantValuePath[reqBody.variantValuePath.length - 1];
             const variantValuePath = prepareIdsForSOQL(
@@ -183,7 +167,6 @@ class PimStructure {
 
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
-            // valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
             Array.from(variantAndValueMap.values()).forEach(valList => {
               valuesList.push.apply(valuesList, valList); // flatten array
             });
@@ -255,13 +238,6 @@ class PimStructure {
                       'Attribute_Label_Type__c'
                     ) === DA_TYPE
                   ) {
-                    // newValue = await parseDigitalAssetAttrVal(
-                    //   digitalAssetMap,
-                    //   newValue,
-                    //   daDownloadDetailsList,
-                    //   helper,
-                    //   reqBody
-                    // );
                     newValue = await parseDaAttrValWithVarMap(
                       valuesList[i].Id,
                       digitalAssetMap,
@@ -422,13 +398,6 @@ class PimStructure {
                     'Attribute_Label_Type__c'
                   ) === DA_TYPE
                 ) {
-                  // newValue = await parseDigitalAssetAttrVal(
-                  //   digitalAssetMap,
-                  //   newValue,
-                  //   daDownloadDetailsList,
-                  //   helper,
-                  //   reqBody
-                  // );
                   newValue = await parseDaAttrValWithVarMap(
                     valuesList[i].Id,
                     digitalAssetMap,
@@ -713,13 +682,6 @@ class PimStructure {
                 'Attribute_Label_Type__c'
               ) === DA_TYPE
             ) {
-              // newValue = await parseDigitalAssetAttrVal(
-              //   digitalAssetMap,
-              //   newValue,
-              //   daDownloadDetailsList,
-              //   helper,
-              //   reqBody
-              // );
               const digitalAsset = digitalAssetMap?.get(newValue);
               if (!digitalAsset) {
                 continue;
@@ -956,20 +918,15 @@ class PimStructure {
         }
 
         if (productVariantsDaDetailsMap.has(currRecordId)) {
-          // daDownloadDetailsList.push(
-          //   Array.from(productVariantsDaDetailsMap.get(currRecordId).values())
-          // );
           daDownloadDetailsList = daDownloadDetailsList.concat(
             Array.from(productVariantsDaDetailsMap.get(currRecordId).values())
           );
         }
       }
     }
-    console.log('daDownloadDetailsList: ', daDownloadDetailsList);
     daDownloadDetailsList = await this.removeDuplicatedAssets(
       daDownloadDetailsList
     );
-    console.log('daDownloadDetailsList2: ', daDownloadDetailsList);
     return daDownloadDetailsList;
   }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -144,10 +144,6 @@ class PimStructure {
               helper,
               reqBody
             );
-            console.log(
-              'productVariantsDaDetailsMap1: ',
-              productVariantsDaDetailsMap
-            );
           } else if (
             helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') ===
             PRODUCT_REFERENCE_TYPE
@@ -225,7 +221,6 @@ class PimStructure {
                 helper.getValue(valuesList[i], 'Label__c')
               );
               currentVariant.set('Id', valuesList[i].Id);
-              console.log('currentVariantL ', currentVariant);
 
               // add any overwritten values belonging to the current variant value
               if (overwrittenValues.length > 0) {
@@ -917,8 +912,6 @@ class PimStructure {
     exportRecords
   ) {
     // Option 1: Check if is inherited
-    console.log('productVariantsDaDetailsMap2: ', productVariantsDaDetailsMap);
-    console.log('exportRecords: ', exportRecords);
     let currRecordId;
     if (isInherited) {
       // iterate over all attribute labels included in the export
@@ -966,9 +959,11 @@ class PimStructure {
         }
       }
     }
+    console.log('daDownloadDetailsList: ', daDownloadDetailsList)
     daDownloadDetailsList = await this.removeDuplicatedAssets(
       daDownloadDetailsList
     );
+    console.log('daDownloadDetailsList2: ', daDownloadDetailsList)
     return daDownloadDetailsList;
   }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -816,10 +816,13 @@ class PimStructure {
       });
     console.log('valuesList: ', valuesList);
     console.log('exportRecords: ', exportRecords);
+    this.updateExportRecordsWithVariantValueIds(valuesList, exportRecords);
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
       console.log('variant: ', variant);
+      // loop through each variant value's child variant values
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
+        // find the child variant value's object in exportRecords
         exportRecords.forEach(variantValue => {
           if (variantValue.get('Record_ID') === childVariant) {
             Array.from(variant.keys()).forEach(key => {
@@ -902,6 +905,21 @@ class PimStructure {
       childMap.set(variant.get('Record_ID'), variant.get('Children'));
     });
     return childMap;
+  }
+
+  updateExportRecordsWithVariantValueIds(valuesList, exportRecords) {
+    let vvIdNameMap = new Map();
+    console.log('vvId: ', valuesList[0].Id);
+    console.log('vvName: ', valuesList[0].Name);
+    for (let variantValue of valuesList) {
+      vvIdNameMap.set(variantValue.Name, variantValue.Id);
+    }
+    for (let record of exportRecords) {
+      const recordName = record.get('Record_ID');
+      if (recordName) {
+        record.set('Id', vvIdNameMap.get(recordName));
+      }
+    }
   }
 
   async getFinalizedDaList(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -339,6 +339,7 @@ class PimStructure {
             variantValueHierarchyMap,
             baseRecord.get('Id')
           );
+          console.log('variantValueHierarchyMap2: ', variantValueHierarchyMap);
           let valuesIdList = [];
           valuesList.forEach(val => {
             valuesIdList.push(val.Id);
@@ -606,6 +607,7 @@ class PimStructure {
         variantValueHierarchyMap.set(vv[0].Id, productId);
       }
     }
+    console.log('variantValueHierarchyMap1: ', variantValueHierarchyMap);
   }
 
   async fillInInheritedData(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -302,6 +302,7 @@ class PimStructure {
             currentVariantName = currentVariant.get('Record_ID');
             // overwrite base product with current variant
             exportRecords = [currentVariant];
+            console.log('currentVariant: ', currentVariant);
           }
         } else if (
           exportType === 'allVariants' ||

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -599,10 +599,11 @@ class PimStructure {
         vv,
         'Parent_Variant_Value__c'
       );
+      console.log('vv: ', vv);
       if (parentVariantValueId) {
-        variantValueHierarchyMap.set(vv.get('Id'), parentVariantValueId);
+        variantValueHierarchyMap.set(vv.Id, parentVariantValueId);
       } else {
-        variantValueHierarchyMap.set(vv.get('Id'), productId);
+        variantValueHierarchyMap.set(vv.Id, productId);
       }
     }
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -508,7 +508,7 @@ class PimStructure {
           exportRecordsAndColumns = [exportRecords];
         }
       }
-      console.log('exportRecordsAndColumns: ', exportRecordsAndColumns);
+      console.log('exportRecordsAndColumns[0]: ', exportRecordsAndColumns[0]);
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
@@ -907,13 +907,13 @@ class PimStructure {
     exportRecords
   ) {
     // Option 1: Check if is inherited
+    let currRecordId;
     if (isInherited) {
       console.log(
         'productVariantsDaDetailsMap FINAL: ',
         productVariantsDaDetailsMap
       );
       // iterate over digital asset attribute labels which the base product has digital assets for
-      let currRecordId;
       for (let labelId of nonEmptyProductDaAttrLabelsIds) {
         for (let record of exportRecords) {
           currRecordId = record.get('Id');
@@ -949,11 +949,12 @@ class PimStructure {
     } else {
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
-        daDownloadDetailsList.push(
-          Array.from(
-            productVariantsDaDetailsMap.get(record.get('Id'))?.values()
-          )
-        );
+        currRecordId = record.get('Id');
+        if (currRecordId) {
+          daDownloadDetailsList.push(
+            Array.from(productVariantsDaDetailsMap.get(currRecordId)?.values())
+          );
+        }
       }
     }
     console.log('daDownloadDetailsList: ', daDownloadDetailsList);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -815,11 +815,12 @@ class PimStructure {
         });
       });
     console.log('valuesList: ', valuesList);
+    console.log('exportRecords: ', exportRecords);
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
+      console.log('variant: ', variant);
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
         exportRecords.forEach(variantValue => {
-          console.log('variantValue: ', variantValue);
           if (variantValue.get('Record_ID') === childVariant) {
             Array.from(variant.keys()).forEach(key => {
               if (

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -914,16 +914,19 @@ class PimStructure {
       // iterate over digital asset attribute labels which the base product has digital assets for
       let currRecordId;
       for (let labelId of nonEmptyProductDaAttrLabelsIds) {
-        console.log('labelId: ', labelId);
         for (let record of exportRecords) {
           currRecordId = record.get('Id');
           while (true) {
             // check if variant value has digital asset for this label, if not iteratively search parent variant values
             // until product is reached
+            console.log('========================');
+            console.log('currRecordId: ', currRecordId);
+            console.log('labelId: ', labelId);
             const currRecordDigitalAsset = productVariantsDaDetailsMap
               .get(currRecordId)
               ?.get(labelId);
             if (currRecordDigitalAsset) {
+              console.log('record with DA: ', currRecordId);
               // add prod/variant val's digital asset for list of assets for export, no need to search in parent
               daDownloadDetailsList.push(currRecordDigitalAsset);
               break;

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -334,6 +334,10 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
+          console.log(
+            'variantValueHierarchyMap before: ',
+            variantValueHierarchyMap
+          );
           await this.populateVariantValueHierarchyMap(
             valuesList,
             variantValueHierarchyMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -756,6 +756,7 @@ class PimStructure {
               newValue = await parseProductReferenceAttrVal(newValue, reqBody);
             }
             // update the newVariant object with the overwritten values
+            console.log('affectedLabelname: ', affectedLabelName);
             newVariant.set(affectedLabelName, newValue);
           }
         }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -508,6 +508,7 @@ class PimStructure {
           exportRecordsAndColumns = [exportRecords];
         }
       }
+      console.log('exportRecordsAndColumns: ', exportRecordsAndColumns);
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -192,19 +192,10 @@ class PimStructure {
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
             valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
-            console.log(
-              'variantValueHierarchyMap before: ',
-              variantValueHierarchyMap
-            );
-            variantValueHierarchyMap =
-              await this.populateVariantValueHierarchyMap(
-                valuesList,
-                variantValueHierarchyMap,
-                baseRecord.get('Id')
-              );
-            console.log(
-              'variantValueHierarchyMap 2: ',
-              variantValueHierarchyMap
+            this.populateVariantValueHierarchyMap(
+              valuesList,
+              variantValueHierarchyMap,
+              baseRecord.get('Id')
             );
             let valuesIdList = [];
             valuesList.forEach(val => {
@@ -343,12 +334,11 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
-          variantValueHierarchyMap =
-            await this.populateVariantValueHierarchyMap(
-              valuesList,
-              variantValueHierarchyMap,
-              baseRecord.get('Id')
-            );
+          this.populateVariantValueHierarchyMap(
+            valuesList,
+            variantValueHierarchyMap,
+            baseRecord.get('Id')
+          );
           let valuesIdList = [];
           valuesList.forEach(val => {
             valuesIdList.push(val.Id);
@@ -598,7 +588,7 @@ class PimStructure {
   }
 
   // creates a Map <Id, Id> with key value pairs being [variantValueId, parentVariantValueId] or [variantValueId, productId]
-  async populateVariantValueHierarchyMap(
+  populateVariantValueHierarchyMap(
     valuesList,
     variantValueHierarchyMap,
     productId
@@ -608,15 +598,12 @@ class PimStructure {
         vv[0],
         'Parent_Variant_Value__c'
       );
-      console.log('vv[0]: ', vv[0]);
       if (parentVariantValueId) {
         variantValueHierarchyMap.set(vv[0].Id, parentVariantValueId);
       } else {
         variantValueHierarchyMap.set(vv[0].Id, productId);
       }
     }
-    console.log('variantValueHierarchyMap1: ', variantValueHierarchyMap);
-    return variantValueHierarchyMap;
   }
 
   async fillInInheritedData(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -817,9 +817,9 @@ class PimStructure {
     console.log('valuesList: ', valuesList);
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
-      console.log('variant: ', variant);
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
         exportRecords.forEach(variantValue => {
+          console.log('variantValue: ', variantValue);
           if (variantValue.get('Record_ID') === childVariant) {
             Array.from(variant.keys()).forEach(key => {
               if (

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -498,7 +498,7 @@ class PimStructure {
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
-          appearingLabelIds.split(', '),
+          appearingLabelIds.replace(/'/g, '').split(', '),
           productVariantsDaDetailsMap,
           daDownloadDetailsList,
           variantValueHierarchyMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -498,7 +498,7 @@ class PimStructure {
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
-          appearingLabelIds.replace(/'/g, '').split(', '),
+          appearingLabelIds.replace(/'/g, '').split(','),
           productVariantsDaDetailsMap,
           daDownloadDetailsList,
           variantValueHierarchyMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -135,6 +135,7 @@ class PimStructure {
             //   helper,
             //   reqBody
             // );
+            console.log('prod Da');
             attrValValue = await parseDaAttrValWithVarMap(
               baseRecord.get('Id'),
               digitalAssetMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -858,7 +858,6 @@ class PimStructure {
   }
 
   async createVariantValueTree(valuesList, baseProduct) {
-    console.log('tree Val list: ', valuesList);
     let variantValueTree = [];
     let treeNode;
 
@@ -899,6 +898,7 @@ class PimStructure {
     variantValueTree.forEach(variant => {
       childMap.set(variant.get('Record_ID'), variant.get('Children'));
     });
+    console.log('childMap: ', childMap);
     return childMap;
   }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -49,7 +49,6 @@ class PimStructure {
       useAspose,
       daDownloadDetailsList = [],
       productVariantsDaDetailsMap,
-      nonEmptyProductDaAttrLabelsIds = [],
       variantValueHierarchyMap = new Map();
     if (reqBody.options.isTemplateExport) {
       if (reqBody.templateVersionData) {
@@ -144,9 +143,6 @@ class PimStructure {
               productVariantsDaDetailsMap,
               helper,
               reqBody
-            );
-            nonEmptyProductDaAttrLabelsIds.push(
-              helper.getValue(appearingValues[j], 'Attribute_Label__c')
             );
           } else if (
             helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') ===
@@ -323,6 +319,8 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
+          console.log('variantAndValueListMap: ', variantAndValueListMap);
+          console.log('valuesList: ', valuesList);
           this.populateVariantValueHierarchyMap(
             valuesList,
             variantValueHierarchyMap,
@@ -912,11 +910,6 @@ class PimStructure {
     // Option 1: Check if is inherited
     let currRecordId;
     if (isInherited) {
-      console.log('appearingLabelIds: ', appearingLabelIds);
-      console.log(
-        'productVariantsDaDetailsMap FINAL: ',
-        productVariantsDaDetailsMap
-      );
       // iterate over all attribute labels included in the export
       for (let labelId of appearingLabelIds) {
         for (let record of exportRecords) {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -135,7 +135,6 @@ class PimStructure {
             //   helper,
             //   reqBody
             // );
-            console.log('prod Da');
             attrValValue = await parseDaAttrValWithVarMap(
               baseRecord.get('Id'),
               digitalAssetMap,
@@ -144,6 +143,10 @@ class PimStructure {
               productVariantsDaDetailsMap,
               helper,
               reqBody
+            );
+            console.log(
+              'productVariantsDaDetailsMap1: ',
+              productVariantsDaDetailsMap
             );
           } else if (
             helper.getValue(appearingValues[j], 'Attribute_Label_Type__c') ===
@@ -914,6 +917,8 @@ class PimStructure {
     exportRecords
   ) {
     // Option 1: Check if is inherited
+    console.log('productVariantsDaDetailsMap2: ', productVariantsDaDetailsMap);
+    console.log('exportRecords: ', exportRecords);
     let currRecordId;
     if (isInherited) {
       // iterate over all attribute labels included in the export

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -966,6 +966,7 @@ class PimStructure {
   }
 
   async removeDuplicatedAssets(daDownloadDetailsList) {
+    console.log('daDownloadDetailsList1: ', daDownloadDetailsList);
     return daDownloadDetailsList.filter(
       (value, index, self) =>
         index ===

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -170,6 +170,8 @@ class PimStructure {
             // exporting current variant value (base product not included in export)
             // remove base product's digital assets that were previously added
             // daDownloadDetailsList = [];
+            const currentVariantId =
+              reqBody.variantValuePath[reqBody.variantValuePath.length - 1];
             const variantValuePath = prepareIdsForSOQL(
               reqBody.variantValuePath
             );
@@ -221,14 +223,14 @@ class PimStructure {
               currentVariant.set('Id', valuesList[i].Id);
               console.log('currentVariantL ', currentVariant);
 
-              // add any overwritten values
+              // add any overwritten values belonging to the current variant value
               if (overwrittenValues.length > 0) {
                 for (let j = 0; j < overwrittenValues.length; j++) {
                   const affectedVariantValue = helper.getValue(
                     overwrittenValues[j],
                     'Overwritten_Variant_Value__c'
                   );
-                  if (valuesList[i].Id !== affectedVariantValue) {
+                  if (currentVariantId !== affectedVariantValue) {
                     // skip attribute values which are not overwriting the current variant value
                     continue;
                   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -596,14 +596,14 @@ class PimStructure {
     variantValueHierarchyMap = new Map();
     for (let vv of valuesList) {
       const parentVariantValueId = helper.getValue(
-        vv,
+        vv[0],
         'Parent_Variant_Value__c'
       );
-      console.log('vv: ', vv);
+      console.log('vv[0]: ', vv[0]);
       if (parentVariantValueId) {
-        variantValueHierarchyMap.set(vv.Id, parentVariantValueId);
+        variantValueHierarchyMap.set(vv[0].Id, parentVariantValueId);
       } else {
-        variantValueHierarchyMap.set(vv.Id, productId);
+        variantValueHierarchyMap.set(vv[0].Id, productId);
       }
     }
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -953,17 +953,20 @@ class PimStructure {
         }
 
         if (productVariantsDaDetailsMap.has(currRecordId)) {
-          daDownloadDetailsList.push(
+          // daDownloadDetailsList.push(
+          //   Array.from(productVariantsDaDetailsMap.get(currRecordId).values())
+          // );
+          daDownloadDetailsList = daDownloadDetailsList.concat(
             Array.from(productVariantsDaDetailsMap.get(currRecordId).values())
           );
         }
       }
     }
-    console.log('daDownloadDetailsList: ', daDownloadDetailsList)
+    console.log('daDownloadDetailsList: ', daDownloadDetailsList);
     daDownloadDetailsList = await this.removeDuplicatedAssets(
       daDownloadDetailsList
     );
-    console.log('daDownloadDetailsList2: ', daDownloadDetailsList)
+    console.log('daDownloadDetailsList2: ', daDownloadDetailsList);
     return daDownloadDetailsList;
   }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -196,11 +196,12 @@ class PimStructure {
               'variantValueHierarchyMap before: ',
               variantValueHierarchyMap
             );
-            await this.populateVariantValueHierarchyMap(
-              valuesList,
-              variantValueHierarchyMap,
-              baseRecord.get('Id')
-            );
+            variantValueHierarchyMap =
+              await this.populateVariantValueHierarchyMap(
+                valuesList,
+                variantValueHierarchyMap,
+                baseRecord.get('Id')
+              );
             console.log(
               'variantValueHierarchyMap 2: ',
               variantValueHierarchyMap
@@ -342,11 +343,12 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
-          await this.populateVariantValueHierarchyMap(
-            valuesList,
-            variantValueHierarchyMap,
-            baseRecord.get('Id')
-          );
+          variantValueHierarchyMap =
+            await this.populateVariantValueHierarchyMap(
+              valuesList,
+              variantValueHierarchyMap,
+              baseRecord.get('Id')
+            );
           let valuesIdList = [];
           valuesList.forEach(val => {
             valuesIdList.push(val.Id);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -322,8 +322,6 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
-          console.log('variantAndValueListMap: ', variantAndValueListMap);
-          console.log('valuesList: ', valuesList);
           this.populateVariantValueHierarchyMap(
             valuesList,
             variantValueHierarchyMap,
@@ -941,6 +939,7 @@ class PimStructure {
         }
       }
     } else {
+      console.log('productVariantsDaDetailsMap: ', productVariantsDaDetailsMap);
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
         console.log('record: ', record);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -249,6 +249,7 @@ class PimStructure {
                     'Value__c'
                   );
                   if (newValue === 'from BLK') {
+                    console.log('valuesList[i].Name: ', valuesList[i].Name);
                     console.log('valuesList[i].Id: ', valuesList[i].Id);
                     console.log('affectedVariantValue: ', affectedVariantValue);
                   }
@@ -292,7 +293,9 @@ class PimStructure {
                   currentVariant.set(affectedLabelName, newValue);
                 }
               }
+              console.log('currentVariant: ', currentVariant);
             }
+
             currentVariantName = currentVariant.get('Record_ID');
             // overwrite base product with current variant
             exportRecords = [currentVariant];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -686,7 +686,6 @@ class PimStructure {
               if (!digitalAsset) {
                 continue;
               }
-              // just need conversion to view link since DA has been stored in productVariantsDaDetailsMap in prev steps
               newValue = await parseDaAttrValWithVarMap(
                 valuesList[i].Id,
                 digitalAssetMap,
@@ -876,7 +875,6 @@ class PimStructure {
     variantValueHierarchyMap,
     exportRecords
   ) {
-    // Option 1: Check if is inherited
     let currRecordId;
     if (isInherited) {
       // iterate over all attribute labels included in the export
@@ -888,7 +886,7 @@ class PimStructure {
           }
           while (true) {
             // check if variant value has digital asset for this label, if not iteratively search parent variant values
-            // until product
+            // until product for digital assets for this label
             const currRecordDigitalAsset = productVariantsDaDetailsMap
               .get(currRecordId)
               ?.get(labelId);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -248,6 +248,10 @@ class PimStructure {
                     overwrittenValues[j],
                     'Value__c'
                   );
+                  if (newValue === 'from BLK') {
+                    console.log('valuesList[i].Id: ', valuesList[i].Id);
+                    console.log('affectedVariantValue: ', affectedVariantValue);
+                  }
                   if (
                     helper.getValue(
                       overwrittenValues[j],

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -614,8 +614,7 @@ class PimStructure {
     appearingLabels,
     currentVariantName,
     reqBody,
-    digitalAssetMap,
-    productVariantsDaDetailsMap
+    digitalAssetMap
   ) {
     let lowestLevelVariantValues;
     if (exportType === 'currentVariant') {
@@ -913,9 +912,9 @@ class PimStructure {
         console.log('labelId: ', labelId);
         for (let record of exportRecords) {
           console.log('record: ', record);
-          console.log('record.Id: ', record.Id);
+          console.log('record.Id: ', record.get('Id'));
           const overwrittenDigitalAsset = productVariantsDaDetailsMap
-            .get(record.Id)
+            .get(record.get('Id'))
             ?.get(labelId);
           if (overwrittenDigitalAsset) {
             // add prod/vv's DA to daDownloadDetailsList
@@ -930,7 +929,9 @@ class PimStructure {
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
         daDownloadDetailsList.push(
-          Array.from(productVariantsDaDetailsMap.get(record.Id)?.values())
+          Array.from(
+            productVariantsDaDetailsMap.get(record.get('Id'))?.values()
+          )
         );
       }
     }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -814,8 +814,10 @@ class PimStructure {
           }
         });
       });
+    console.log('valuesList: ', valuesList);
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
+      console.log('variant: ', variant);
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
         exportRecords.forEach(variantValue => {
           if (variantValue.get('Record_ID') === childVariant) {
@@ -898,7 +900,6 @@ class PimStructure {
     variantValueTree.forEach(variant => {
       childMap.set(variant.get('Record_ID'), variant.get('Children'));
     });
-    console.log('childMap: ', childMap);
     return childMap;
   }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -183,7 +183,7 @@ class PimStructure {
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
             valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
-            console.log('valList[1][0]: ', valuesList[1][0]);
+            console.log('valList[1]: ', valuesList[1]);
             this.populateVariantValueHierarchyMap(
               valuesList,
               variantValueHierarchyMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -219,6 +219,7 @@ class PimStructure {
                 helper.getValue(valuesList[i], 'Label__c')
               );
               currentVariant.set('Id', valuesList[i].Id);
+              console.log('currentVariantL ', currentVariant);
 
               // add any overwritten values
               if (overwrittenValues.length > 0) {
@@ -248,11 +249,6 @@ class PimStructure {
                     overwrittenValues[j],
                     'Value__c'
                   );
-                  if (newValue === 'from BLK') {
-                    console.log('valuesList[i].Name: ', valuesList[i].Name);
-                    console.log('valuesList[i].Id: ', valuesList[i].Id);
-                    console.log('affectedVariantValue: ', affectedVariantValue);
-                  }
                   if (
                     helper.getValue(
                       overwrittenValues[j],
@@ -293,7 +289,6 @@ class PimStructure {
                   currentVariant.set(affectedLabelName, newValue);
                 }
               }
-              console.log('currentVariant: ', currentVariant);
             }
 
             currentVariantName = currentVariant.get('Record_ID');

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -12,7 +12,6 @@ const {
   initAssetDownloadDetailsList,
   parseDigitalAssetAttrVal,
   parseDaAttrValWithVarMap,
-  getDigitalAssetViewLink,
   prepareIdsForSOQL,
   parseProductReferenceAttrVal
 } = require('./utils');
@@ -602,7 +601,8 @@ class PimStructure {
     appearingLabels,
     currentVariantName,
     reqBody,
-    digitalAssetMap
+    digitalAssetMap,
+    productVariantsDaDetailsMap
   ) {
     let lowestLevelVariantValues;
     if (exportType === 'currentVariant') {
@@ -725,9 +725,12 @@ class PimStructure {
                 continue;
               }
               // just need conversion to view link since DA has been stored in productVariantsDaDetailsMap in prev steps
-              newValue = await getDigitalAssetViewLink(
-                digitalAsset,
+              newValue = await parseDaAttrValWithVarMap(
+                valuesList[i].Id,
+                digitalAssetMap,
+                helper.getValue(overwrittenValues[j], 'Attribute_Label__c'),
                 newValue,
+                productVariantsDaDetailsMap,
                 helper,
                 reqBody
               );

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -946,6 +946,7 @@ class PimStructure {
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
         currRecordId = record.get('Id');
+        console.log('currRecordId: ', currRecordId);
         if (!currRecordId) {
           continue;
         }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -967,16 +967,15 @@ class PimStructure {
 
   async removeDuplicatedAssets(daDownloadDetailsList) {
     console.log('daDownloadDetailsList1: ', daDownloadDetailsList);
-    return daDownloadDetailsList.filter(
-      (value, index, self) =>
+    return daDownloadDetailsList.filter((value, index) => {
+      const _value = JSON.stringify(value);
+      return (
         index ===
-        self.findIndex(
-          t =>
-            t.fileName === value.fileName &&
-            t.fileId === value.fileId &&
-            t.key === value.key
-        )
-    );
+        daDownloadDetailsList.findIndex(obj => {
+          return JSON.stringify(obj) === _value;
+        })
+      );
+    });
   }
 
   async addExportColumns(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -183,6 +183,7 @@ class PimStructure {
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
             valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
+            console.log('valList[1][0]: ', valuesList[1][0]);
             this.populateVariantValueHierarchyMap(
               valuesList,
               variantValueHierarchyMap,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -192,7 +192,7 @@ class PimStructure {
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
             valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
-            this.populateVariantValueHierarchyMap(
+            await this.populateVariantValueHierarchyMap(
               valuesList,
               variantValueHierarchyMap,
               baseRecord.get('Id')
@@ -334,16 +334,11 @@ class PimStructure {
           Array.from(variantAndValueListMap.values()).forEach(valList => {
             valuesList.push.apply(valuesList, valList); // flatten array
           });
-          console.log(
-            'variantValueHierarchyMap before: ',
-            variantValueHierarchyMap
-          );
           await this.populateVariantValueHierarchyMap(
             valuesList,
             variantValueHierarchyMap,
             baseRecord.get('Id')
           );
-          console.log('variantValueHierarchyMap2: ', variantValueHierarchyMap);
           let valuesIdList = [];
           valuesList.forEach(val => {
             valuesIdList.push(val.Id);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -224,6 +224,7 @@ class PimStructure {
                 varList[i].Name,
                 helper.getValue(valuesList[i][0], 'Label__c')
               );
+              currentVariant.set('Id', valuesList[i][0].Id);
 
               // add any overwritten values
               if (overwrittenValues.length > 0) {
@@ -368,6 +369,7 @@ class PimStructure {
               // add variant value's Record ID
               if (isFirstLevelVariant) {
                 newVariant.set('Record_ID', currValue.Name);
+                newVariant.set('Id', currValue.Id);
                 isFirstLevelVariant = false;
               }
               // add Variant__c's Label (e.g. for Variant 'Size', Label is 'Large')

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -606,6 +606,7 @@ class PimStructure {
         variantValueHierarchyMap.set(vv[0].Id, productId);
       }
     }
+    console.log('variantValueHierarchyMap1: ', variantValueHierarchyMap);
   }
 
   async fillInInheritedData(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -942,11 +942,9 @@ class PimStructure {
         }
       }
     } else {
-      console.log('productVariantsDaDetailsMap: ', productVariantsDaDetailsMap);
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
         currRecordId = record.get('Id');
-        console.log('currRecordId: ', currRecordId);
         if (!currRecordId) {
           continue;
         }
@@ -961,12 +959,10 @@ class PimStructure {
     daDownloadDetailsList = await this.removeDuplicatedAssets(
       daDownloadDetailsList
     );
-    console.log('daDownloadDetailsList: ', daDownloadDetailsList);
     return daDownloadDetailsList;
   }
 
   async removeDuplicatedAssets(daDownloadDetailsList) {
-    console.log('daDownloadDetailsList1: ', daDownloadDetailsList);
     return daDownloadDetailsList.filter((value, index) => {
       const _value = JSON.stringify(value);
       return (

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -600,9 +600,9 @@ class PimStructure {
         'Parent_Variant_Value__c'
       );
       if (parentVariantValueId) {
-        variantValueHierarchyMap.set(vv.Id, parentVariantValueId);
+        variantValueHierarchyMap.set(vv.get('Id'), parentVariantValueId);
       } else {
-        variantValueHierarchyMap.set(vv.Id, productId);
+        variantValueHierarchyMap.set(vv.get('Id'), productId);
       }
     }
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -957,8 +957,17 @@ class PimStructure {
         }
       }
     }
+    await this.removeDuplicatedAssets(daDownloadDetailsList);
     console.log('daDownloadDetailsList: ', daDownloadDetailsList);
     return daDownloadDetailsList;
+  }
+
+  async removeDuplicatedAssets(daDownloadDetailsList) {
+    daDownloadDetailsList = daDownloadDetailsList.filter(
+      (value, index, self) =>
+        index ===
+        self.findIndex(t => t.place === value.place && t.name === value.name)
+    );
   }
 
   async addExportColumns(

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -966,7 +966,12 @@ class PimStructure {
     daDownloadDetailsList = daDownloadDetailsList.filter(
       (value, index, self) =>
         index ===
-        self.findIndex(t => t.place === value.place && t.name === value.name)
+        self.findIndex(
+          t =>
+            t.fileName === value.fileName &&
+            t.fileId === value.fileId &&
+            t.key === value.key
+        )
     );
   }
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -186,7 +186,6 @@ class PimStructure {
             Array.from(variantAndValueMap.values()).forEach(valList => {
               valuesList.push.apply(valuesList, valList); // flatten array
             });
-            console.log('valList[1]: ', valuesList[1]);
             this.populateVariantValueHierarchyMap(
               valuesList,
               variantValueHierarchyMap,
@@ -194,7 +193,7 @@ class PimStructure {
             );
             let valuesIdList = [];
             valuesList.forEach(val => {
-              valuesIdList.push(val[0].Id);
+              valuesIdList.push(val.Id);
             });
             valuesIdList = prepareIdsForSOQL(valuesIdList);
             let overwrittenValues = [];
@@ -214,12 +213,12 @@ class PimStructure {
 
             // add variant values to the current variant product
             for (let i = 0; i < varList.length; i++) {
-              currentVariant.set('Record_ID', valuesList[i][0].Name);
+              currentVariant.set('Record_ID', valuesList[i].Name);
               currentVariant.set(
                 varList[i].Name,
-                helper.getValue(valuesList[i][0], 'Label__c')
+                helper.getValue(valuesList[i], 'Label__c')
               );
-              currentVariant.set('Id', valuesList[i][0].Id);
+              currentVariant.set('Id', valuesList[i].Id);
 
               // add any overwritten values
               if (overwrittenValues.length > 0) {
@@ -228,7 +227,7 @@ class PimStructure {
                     overwrittenValues[j],
                     'Overwritten_Variant_Value__c'
                   );
-                  if (valuesList[i][0].Id !== affectedVariantValue) {
+                  if (valuesList[i].Id !== affectedVariantValue) {
                     // skip attribute values which are not overwriting the current variant value
                     continue;
                   }
@@ -263,7 +262,7 @@ class PimStructure {
                     //   reqBody
                     // );
                     newValue = await parseDaAttrValWithVarMap(
-                      valuesList[i][0].Id,
+                      valuesList[i].Id,
                       digitalAssetMap,
                       helper.getValue(
                         overwrittenValues[j],

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -924,23 +924,15 @@ class PimStructure {
           while (true) {
             // check if variant value has digital asset for this label, if not iteratively search parent variant values
             // until product
-            console.log('========================');
-            console.log('currRecordId: ', currRecordId);
-            console.log('labelId: ', labelId);
             const currRecordDigitalAsset = productVariantsDaDetailsMap
               .get(currRecordId)
               ?.get(labelId);
             if (currRecordDigitalAsset) {
-              console.log('record with DA: ', currRecordId);
               // add prod/variant val's digital asset for list of assets for export, move on to next label
               daDownloadDetailsList.push(currRecordDigitalAsset);
               break;
             } else {
               // variant val doesn't have DA for this attr label, search upwards for DA i.e. parent variant vals then product
-              console.log(
-                'variantValueHierarchyMap: ',
-                variantValueHierarchyMap
-              );
               const parentRecordId = variantValueHierarchyMap.get(currRecordId);
               if (parentRecordId) {
                 currRecordId = parentRecordId;

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -192,10 +192,18 @@ class PimStructure {
             let currentVariant = new Map();
             const varList = Array.from(variantAndValueMap.keys());
             valuesList = Array.from(variantAndValueMap.values()); // note: this is an array of arrays
+            console.log(
+              'variantValueHierarchyMap before: ',
+              variantValueHierarchyMap
+            );
             await this.populateVariantValueHierarchyMap(
               valuesList,
               variantValueHierarchyMap,
               baseRecord.get('Id')
+            );
+            console.log(
+              'variantValueHierarchyMap 2: ',
+              variantValueHierarchyMap
             );
             let valuesIdList = [];
             valuesList.forEach(val => {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -915,6 +915,9 @@ class PimStructure {
       for (let labelId of appearingLabelIds) {
         for (let record of exportRecords) {
           currRecordId = record.get('Id');
+          if (!currRecordId) {
+            continue;
+          }
           while (true) {
             // check if variant value has digital asset for this label, if not iteratively search parent variant values
             // until product
@@ -942,13 +945,14 @@ class PimStructure {
       console.log('productVariantsDaDetailsMap: ', productVariantsDaDetailsMap);
       for (let record of exportRecords) {
         // add all the DAs belonging to variant vals and product slated for export to daDownloadDetailsList
-        console.log('record: ', record);
         currRecordId = record.get('Id');
-        console.log('currRecordId 1: ', currRecordId);
-        if (currRecordId) {
-          console.log('currRecordId 2: ', currRecordId);
+        if (!currRecordId) {
+          continue;
+        }
+
+        if (productVariantsDaDetailsMap.has(currRecordId)) {
           daDownloadDetailsList.push(
-            Array.from(productVariantsDaDetailsMap.get(currRecordId)?.values())
+            Array.from(productVariantsDaDetailsMap.get(currRecordId).values())
           );
         }
       }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -761,7 +761,6 @@ class PimStructure {
         }
         exportRecords.push(newVariant);
       }
-      console.log('exportRecords1: ', exportRecords);
       exportType = 'currentVariant';
     } else if (exportType === 'lowestVariants') {
       lowestLevelVariantValues = await getLowestVariantValuesList(
@@ -815,7 +814,6 @@ class PimStructure {
           }
         });
       });
-    console.log('filledInExportRecord1: ', filledInExportRecords);
     // loop through each variant (top down) to settle inheritance from parent variants
     exportRecords.forEach(variant => {
       variantValueTree.get(variant.get('Record_ID')).forEach(childVariant => {
@@ -860,6 +858,7 @@ class PimStructure {
   }
 
   async createVariantValueTree(valuesList, baseProduct) {
+    console.log('tree Val list: ', valuesList);
     let variantValueTree = [];
     let treeNode;
 

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -579,13 +579,13 @@ class PimStructure {
   ) {
     for (let vv of valuesList) {
       const parentVariantValueId = helper.getValue(
-        vv[0],
+        vv,
         'Parent_Variant_Value__c'
       );
       if (parentVariantValueId) {
-        variantValueHierarchyMap.set(vv[0].Id, parentVariantValueId);
+        variantValueHierarchyMap.set(vv.Id, parentVariantValueId);
       } else {
-        variantValueHierarchyMap.set(vv[0].Id, productId);
+        variantValueHierarchyMap.set(vv.Id, productId);
       }
     }
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -912,13 +912,13 @@ class PimStructure {
     // Option 1: Check if is inherited
     let currRecordId;
     if (isInherited) {
+      console.log('appearingLabelIds: ', appearingLabelIds);
       console.log(
         'productVariantsDaDetailsMap FINAL: ',
         productVariantsDaDetailsMap
       );
       // iterate over all attribute labels included in the export
       for (let labelId of appearingLabelIds) {
-        console.log('labelId: ', labelId);
         for (let record of exportRecords) {
           currRecordId = record.get('Id');
           while (true) {

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -87,7 +87,6 @@ module.exports = {
   logErrorResponse,
   parseDigitalAssetAttrVal,
   parseDaAttrValWithVarMap,
-  getDigitalAssetViewLink,
   postToChatter,
   prependCDNToViewLink,
   prepareIdsForSOQL,
@@ -392,10 +391,6 @@ async function parseDaAttrValWithVarMap(
       .get(recordId)
       .set(attrLabel, new DADownloadDetails(digitalAsset, reqBody.namespace));
   }
-
-  // productVariantsDaDetailsMap.push(
-  //   new DADownloadDetails(digitalAsset, reqBody.namespace)
-  // );
   return await getDigitalAssetViewLink(
     digitalAsset,
     attrValValue,


### PR DESCRIPTION
Added inheritance for digital asset export by keeping track of digital assets after parsing in a `Map<productId/variantValueId, Map<attributeLabelId, digitalAssetObject>>`

Recording for demo would be too exhaustive so here's a list of the scenarios I tested, covering all export types and both digital asset and non-digital asset fields
![image](https://github.com/PropelPLM/pim-data-service/assets/77341283/dc57e08b-3dd2-41e7-950b-7723a60923fe)
