### PR TITLE
PIM-1078: PIM | Export | Template export without attribute flag should simply return template

### DIFF
--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -105,7 +105,10 @@ function convertArrayOfObjectsToCSV(
     lineDivider,
     recordAttributes;
   // check if "objectRecords" parameter is null, then return from function
-  if (records == null || !records.length) {
+  if (
+    (records == null || !records.length) &&
+    (templateAdditionalHeaders == null || !templateAdditionalHeaders.length)
+  ) {
     return null;
   }
   // store ,[comma] in columnDivider variable for separate CSV values and

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -54,7 +54,7 @@ class PimStructure {
         ({ templateFields, templateHeaders } = this.getTemplateHeadersAndFields(
           reqBody.templateVersionData
         ));
-        if (templateFields.length === 0) {
+        if (!templateFields.length) {
           const template = {
             daDownloadDetailsList: [],
             recordsAndCols: [[], []],

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -55,12 +55,11 @@ class PimStructure {
           reqBody.templateVersionData
         ));
         if (!templateFields.length) {
-          const template = {
+          return {
             daDownloadDetailsList: [],
             recordsAndCols: [[], []],
             templateAdditionalHeaders: templateHeaders
           };
-          return template;
         }
       } else if (reqBody.templateContentVersionId) {
         useAspose = true;

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -54,6 +54,14 @@ class PimStructure {
         ({ templateFields, templateHeaders } = this.getTemplateHeadersAndFields(
           reqBody.templateVersionData
         ));
+        if (templateFields.length === 0) {
+          const template = {
+            daDownloadDetailsList: [],
+            recordsAndCols: [[], []],
+            templateAdditionalHeaders: templateHeadersAndFields.templateHeaders
+          };
+          return template;
+        }
       } else if (reqBody.templateContentVersionId) {
         useAspose = true;
       }
@@ -1114,14 +1122,6 @@ class PimStructure {
         break;
       }
       templateHeadersAndFields.templateHeaders.push(row.split(','));
-    }
-    if (templateHeadersAndFields.templateFields.length === 0) {
-      const template = {
-        daDownloadDetailsList: [],
-        recordsAndCols: [[], []],
-        templateAdditionalHeaders: templateHeadersAndFields.templateHeaders
-      };
-      return template;
     }
     return templateHeadersAndFields;
   }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -1115,6 +1115,14 @@ class PimStructure {
       }
       templateHeadersAndFields.templateHeaders.push(row.split(','));
     }
+    if (templateHeadersAndFields.templateFields.length === 0) {
+      const template = {
+        daDownloadDetailsList: [],
+        recordsAndCols: [[], []],
+        templateAdditionalHeaders: templateHeadersAndFields.templateHeaders
+      };
+      return template;
+    }
     return templateHeadersAndFields;
   }
 }

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -58,7 +58,7 @@ class PimStructure {
           const template = {
             daDownloadDetailsList: [],
             recordsAndCols: [[], []],
-            templateAdditionalHeaders: templateHeadersAndFields.templateHeaders
+            templateAdditionalHeaders: templateHeaders
           };
           return template;
         }

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -481,7 +481,7 @@ async function callAsposeToExport({
     templateContentVersionId
   } = reqBody;
   const options = {
-    hostname: 'propel-document-java-staging.herokuapp.com',
+    hostname: 'propel-document-java-dev.herokuapp.com',
     path: '/v2/pimTemplateExport',
     method: 'POST',
     headers: {

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -481,7 +481,7 @@ async function callAsposeToExport({
     templateContentVersionId
   } = reqBody;
   const options = {
-    hostname: 'propel-document-java-dev.herokuapp.com',
+    hostname: 'propel-document-java-staging.herokuapp.com',
     path: '/v2/pimTemplateExport',
     method: 'POST',
     headers: {


### PR DESCRIPTION
https://github.com/PropelPLM/pim-data-service/assets/77341283/78113156-3f10-4765-854b-bc006cff30ba


- return xlsx template without modification if no attribute flags are found

Link to PR for propel-document-java: https://github.com/PropelPLM/propel-document-java/pull/40