### PR TITLE
PIM-1276: PIM | Import | Support digital asset creation with other CDN urls

### DIFF
--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -462,12 +462,15 @@ ${JSON.stringify(data)}
     //   console.log('problem with request: ' + e.message);
     // });
 
+
     // this.conn.apex.get('/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE', function(err, res) {
     //   if (err) { return console.error(err); }
     //   console.log("response: ", res);
     //   // the response object structure depends on the definition of apex class
     // });
 
+    const sessId = this.sessionId;
+    console.log('sessId: ', sessId)
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
@@ -475,7 +478,7 @@ ${JSON.stringify(data)}
           method: "GET",
           headers: {
             'Content-Type': 'text/plain',
-            'Authorization': 'OAuth ' + this.sessionId
+            'Authorization': 'OAuth ' + sessId
           }
       }, function(err, response, body) {
           console.log('err: ', err)

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -424,12 +424,20 @@ ${JSON.stringify(data)}
   }
 
   /** calls APEX REST API to get a Map of supported <CDN Base Url, Label> */
-  getCDNBaseUrlLabelMap() {
+  async getCDNBaseUrlLabelMap() {
+    return await getPimConstantsApiData('cdnLabelMap');
+  }
+
+  async getLabelCDNBaseUrlMap() {
+    return await getPimConstantsApiData('labelCDNMap');
+  }
+
+  getPimConstantsApiData(type) {
     const accessToken = this.sessionId;
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
-          url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=cdnLabelMap',
+          url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=' + type,
           method: "GET",
           headers: {
             'Content-Type': 'text/plain',

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -481,8 +481,6 @@ ${JSON.stringify(data)}
             'Authorization': 'OAuth ' + accessToken
           }
       }, function(err, response, body) {
-          console.log('err: ', err)
-          console.log('body: ', body)
           if (response.statusCode == 200) {
             resolve(body);
           } else {

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -435,11 +435,12 @@ ${JSON.stringify(data)}
 
   getPimConstantsCDNData(type) {
     const accessToken = this.sessionId;
+    const hostUrl = this.serverUrl;
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
           //url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=' + type,
-          url: this.serverUrl + '/services/apexrest/pim/constants?type=' + type,
+          url: hostUrl + '/services/apexrest/pim/constants?type=' + type,
           method: "GET",
           headers: {
             'Content-Type': 'text/plain',

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -435,10 +435,9 @@ ${JSON.stringify(data)}
 
   getPimConstantsCDNData(type) {
     const accessToken = this.sessionId;
-    const hostUrl = this.serverUrl;
+    const hostUrl = this.serverUrl.includes('https://') ? this.serverUrl : 'https://' + this.serverUrl;
     return new Promise(function (resolve, reject) {
       let request = require("request");
-      console.log('URI: ' + hostUrl + '/services/apexrest/pim/constants?type=' + type);
       request({
           url: hostUrl + '/services/apexrest/pim/constants?type=' + type,
           method: "GET",

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -424,19 +424,18 @@ ${JSON.stringify(data)}
   }
 
   getCDNBaseUrlLabelMap() {
-    console.log('this.serverUrl: ', this.serverUrl)
-    const req = {
-       url: '/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
-       method: 'get',
-       body: '',
-       headers : {
-               "Content-Type" : "application/json"
-           }
-     };
-     this.conn.request(req, function(err, resp) {
-      console.log('res: ', resp);
-      console.log('err: ', err);
-    });
+    // const req = {
+    //    url: '/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
+    //    method: 'get',
+    //    body: '',
+    //    headers : {
+    //            "Content-Type" : "application/json"
+    //        }
+    //  };
+    //  this.conn.request(req, function(err, resp) {
+    //   console.log('res: ', resp);
+    //   console.log('err: ', err);
+    // });
 
     
     // const options = {
@@ -468,6 +467,23 @@ ${JSON.stringify(data)}
     //   console.log("response: ", res);
     //   // the response object structure depends on the definition of apex class
     // });
+
+    return new Promise(function (resolve, reject) {
+      let request = require("request");
+      request({
+          url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
+          method: "GET"
+      }, function(err, response, body) {
+          console.log('response: ', response)
+          console.log('err: ', err)
+          console.log('body: ', body)
+          if (response.headers) {
+            resolve(body);
+          } else {
+            reject(err);
+          }
+      });
+    });
   }
 }
 

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -425,11 +425,11 @@ ${JSON.stringify(data)}
 
   /** calls APEX REST API to get a Map of supported <CDN Base Url, Label> */
   async getCDNBaseUrlLabelMap() {
-    return await getPimConstantsApiData('cdnLabelMap');
+    return await this.getPimConstantsApiData('cdnLabelMap');
   }
 
   async getLabelCDNBaseUrlMap() {
-    return await getPimConstantsApiData('labelCDNMap');
+    return await this.getPimConstantsApiData('labelCDNMap');
   }
 
   getPimConstantsApiData(type) {

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -474,7 +474,7 @@ ${JSON.stringify(data)}
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
-          url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
+          url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=cdnLabelMap',
           method: "GET",
           headers: {
             'Content-Type': 'text/plain',
@@ -483,7 +483,7 @@ ${JSON.stringify(data)}
       }, function(err, response, body) {
           console.log('err: ', err)
           console.log('body: ', body)
-          if (response.headers) {
+          if (response.statusCode == 200) {
             resolve(body);
           } else {
             reject(err);

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -423,54 +423,9 @@ ${JSON.stringify(data)}
     return flatResults
   }
 
+  /** calls APEX REST API to get a Map of supported <CDN Base Url, Label> */
   getCDNBaseUrlLabelMap() {
-    // const req = {
-    //    url: '/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
-    //    method: 'get',
-    //    body: '',
-    //    headers : {
-    //            "Content-Type" : "application/json"
-    //        }
-    //  };
-    //  this.conn.request(req, function(err, resp) {
-    //   console.log('res: ', resp);
-    //   console.log('err: ', err);
-    // });
-
-    
-    // const options = {
-    //   hostname: this.serverUrl.replace('https://', ''),
-    //   path: '/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
-    //   method: 'GET',
-    //   headers: {
-    //     'Content-Type': `multipart/form-data; boundary="a7V4kRcFA8E79pivMuV2tukQ85cmNKeoEgJgq"`,
-    //     'Authorization': 'OAuth ' + this.sessionId
-    //   }
-    // }
-    // console.log('this.serverUrl: ', this.serverUrl.replace('https://', ''))
-    // // var base64data = new Buffer(filedata).toString('base64');
-    // let req = https.request(options, (res) => {
-    //   console.log('res status: ', res.statusCode)
-    //   console.log('HEADERS: ' + JSON.stringify(res.headers));
-    //   res.setEncoding('utf8');
-    //   res.on('data', function (chunk) {
-    //     console.log('BODY: ' + chunk);
-    //   });
-    // });
-
-    // req.on('error', function(e) {
-    //   console.log('problem with request: ' + e.message);
-    // });
-
-
-    // this.conn.apex.get('/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE', function(err, res) {
-    //   if (err) { return console.error(err); }
-    //   console.log("response: ", res);
-    //   // the response object structure depends on the definition of apex class
-    // });
-
     const accessToken = this.sessionId;
-    console.log('accessToken: ', accessToken)
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -439,7 +439,6 @@ ${JSON.stringify(data)}
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
-          //url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=' + type,
           url: hostUrl + '/services/apexrest/pim/constants?type=' + type,
           method: "GET",
           headers: {

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -438,6 +438,7 @@ ${JSON.stringify(data)}
     const hostUrl = this.serverUrl;
     return new Promise(function (resolve, reject) {
       let request = require("request");
+      console.log('URI: ' + hostUrl + '/services/apexrest/pim/constants?type=' + type);
       request({
           url: hostUrl + '/services/apexrest/pim/constants?type=' + type,
           method: "GET",

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -424,6 +424,7 @@ ${JSON.stringify(data)}
   }
 
   getCDNBaseUrlLabelMap() {
+    console.log('this.serverUrl: ', this.serverUrl)
     const req = {
        url: '/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
        method: 'get',

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -446,7 +446,7 @@ ${JSON.stringify(data)}
             'Authorization': 'OAuth ' + accessToken
           }
       }, function(err, response, body) {
-          if (response.statusCode == 200) {
+          if (response && response.statusCode == 200) {
             resolve(body);
           } else {
             reject(err);

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -425,14 +425,15 @@ ${JSON.stringify(data)}
 
   /** calls APEX REST API to get a Map of supported <CDN Base Url, Label> */
   async getCDNBaseUrlLabelMap() {
-    return await this.getPimConstantsApiData('cdnLabelMap');
+    return await this.getPimConstantsCDNData('cdnLabelMap');
   }
 
+  /** calls APEX REST API to get a Map of supported <Label, CDN Base Url> */
   async getLabelCDNBaseUrlMap() {
-    return await this.getPimConstantsApiData('labelCDNMap');
+    return await this.getPimConstantsCDNData('labelCDNMap');
   }
 
-  getPimConstantsApiData(type) {
+  getPimConstantsCDNData(type) {
     const accessToken = this.sessionId;
     return new Promise(function (resolve, reject) {
       let request = require("request");

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -438,7 +438,8 @@ ${JSON.stringify(data)}
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
-          url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=' + type,
+          //url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/constants?type=' + type,
+          url: this.serverUrl + '/services/apexrest/pim/constants?type=' + type,
           method: "GET",
           headers: {
             'Content-Type': 'text/plain',

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -472,9 +472,12 @@ ${JSON.stringify(data)}
       let request = require("request");
       request({
           url: 'https://pim-kim-2-dev-ed.develop.my.salesforce.com/services/apexrest/pim/product/?id=a0GHu000012ePdoMAE',
-          method: "GET"
+          method: "GET",
+          headers: {
+            'Content-Type': 'text/plain',
+            'Authorization': 'OAuth ' + this.sessionId
+          }
       }, function(err, response, body) {
-          console.log('response: ', response)
           console.log('err: ', err)
           console.log('body: ', body)
           if (response.headers) {

--- a/legacy/ForceService.js
+++ b/legacy/ForceService.js
@@ -469,8 +469,8 @@ ${JSON.stringify(data)}
     //   // the response object structure depends on the definition of apex class
     // });
 
-    const sessId = this.sessionId;
-    console.log('sessId: ', sessId)
+    const accessToken = this.sessionId;
+    console.log('accessToken: ', accessToken)
     return new Promise(function (resolve, reject) {
       let request = require("request");
       request({
@@ -478,7 +478,7 @@ ${JSON.stringify(data)}
           method: "GET",
           headers: {
             'Content-Type': 'text/plain',
-            'Authorization': 'OAuth ' + sessId
+            'Authorization': 'OAuth ' + accessToken
           }
       }, function(err, response, body) {
           console.log('err: ', err)

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -47,7 +47,7 @@ logErrorResponse = (err, functionName) => {
 getDigitalAssetMap = async (service, helper) => {
   const digitalAssetList = await service.simpleQuery(
     helper.namespaceQuery(
-      `select Id, Name, External_File_Id__c, View_Link__c, Mime_Type__c
+      `select Id, Name, External_File_Id__c, View_Link__c, Mime_Type__c, Content_Location__c
       from Digital_Asset__c`
     )
   );

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -326,10 +326,7 @@ async function prependCDNToViewLink(viewLink, contentLocation, reqBody) {
   const service = new ForceService(reqBody.hostUrl, reqBody.sessionId);
 
   let prefix = '';
-  console.log('viewLink: ', viewLink)
-  console.log('contentLocation: ', contentLocation)
   if (viewLink && contentLocation) {
-    console.log('reached if')
     const stringifiedLabelCDNBaseUrlMap = await service.getLabelCDNBaseUrlMap();
     const cdnBaseUrlLabelMap = new Map(Object.entries(JSON.parse(stringifiedLabelCDNBaseUrlMap)));
     prefix = cdnBaseUrlLabelMap.get(contentLocation);

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -322,24 +322,16 @@ function validateNamespaceForField(namespace) {
   }
 }
 
-async function prependCDNToViewLink(viewLink, reqBody) {
+async function prependCDNToViewLink(viewLink, contentLocation, reqBody) {
   const service = new ForceService(reqBody.hostUrl, reqBody.sessionId);
-  const helper = new PimExportHelper(reqBody.namespace);
-  const CDN_METADATA_NAME = 'CloudfrontDistribution';
 
-  if (viewLink !== null || !viewLink.isEmpty()) {
-    const prefix = await service.simpleQuery(
-      helper.namespaceQuery(
-        `select Id, Value__c
-        from Configuration__mdt
-        where DeveloperName = '${CDN_METADATA_NAME}'`
-      )
-    );
-    if (prefix.length > 0) {
-      return helper.getValue(prefix[0], 'Value__c') + viewLink;
-    }
+  let prefix = '';
+  if (viewLink && contentLocation) {
+    const stringifiedLabelCDNBaseUrlMap = await service.getLabelCDNBaseUrlMap();
+    const cdnBaseUrlLabelMap = new Map(Object.entries(JSON.parse(stringifiedLabelCDNBaseUrlMap)));
+    prefix = cdnBaseUrlLabelMap.get(contentLocation);
   }
-  return viewLink;
+  return prefix + 'asdflj' + viewLink;
 }
 
 async function parseDigitalAssetAttrVal(
@@ -406,10 +398,11 @@ async function getDigitalAssetViewLink(
   reqBody
 ) {
   const viewLink = helper.getValue(digitalAsset, 'View_Link__c');
+  const contentLocation = helper.getValue(digitalAsset, 'Content_Location__c');
   // if value is already complete url, add it to the map, else prepend the CDN url to the partial url then add to map
   attrValValue = viewLink.includes('https')
     ? viewLink
-    : await module.exports.prependCDNToViewLink(viewLink, reqBody);
+    : await module.exports.prependCDNToViewLink(viewLink, contentLocation, reqBody);
   return attrValValue;
 }
 

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -326,12 +326,15 @@ async function prependCDNToViewLink(viewLink, contentLocation, reqBody) {
   const service = new ForceService(reqBody.hostUrl, reqBody.sessionId);
 
   let prefix = '';
+  console.log('viewLink: ', viewLink)
+  console.log('contentLocation: ', contentLocation)
   if (viewLink && contentLocation) {
+    console.log('reached if')
     const stringifiedLabelCDNBaseUrlMap = await service.getLabelCDNBaseUrlMap();
     const cdnBaseUrlLabelMap = new Map(Object.entries(JSON.parse(stringifiedLabelCDNBaseUrlMap)));
     prefix = cdnBaseUrlLabelMap.get(contentLocation);
   }
-  return prefix + 'asdflj' + viewLink;
+  return prefix + viewLink;
 }
 
 async function parseDigitalAssetAttrVal(

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -236,25 +236,30 @@ class ImportAssetMetadata extends ImportClass {
   }
 
   async getAssetSizeAndType(url) {
-    let request = require("request");
-    request({
-        url: url,
-        method: "HEAD"
-    }, await function(err, response, body) {
-      console.log('url: ', url);
-        if (response.headers) {
-          console.log(response.headers);
-          console.log(response.headers['content-type']);
-          console.log(response.headers['content-length']);
-          return {
-            mimeType: response.headers['content-type'],
-            assetSize: response.headers['content-length']
+    return new Promise(function (resolve, reject) {
+      let request = require("request");
+      request({
+          url: url,
+          method: "HEAD"
+      }, function(err, response, body) {
+        console.log('url: ', url);
+          if (response.headers) {
+            console.log(response.headers);
+            console.log(response.headers['content-type']);
+            console.log(response.headers['content-length']);
+            // return {
+            //   mimeType: response.headers['content-type'],
+            //   assetSize: response.headers['content-length']
+            // }
+            resolve(response.headers);
+          } else {
+            reject(err);
           }
-        }
-        return {
-          mimeType: null,
-          assetSize: null
-        }
+          // return {
+          //   mimeType: null,
+          //   assetSize: null
+          // }
+      });
     });
   }
 

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -13,11 +13,11 @@ class ImportAssetMetadata extends ImportClass {
   constructor(req, res) {
     super(req, res);
 
-    this.assetNames = [];
+    this.existingAssetNames = [];
     this.parentNames = [];
     this.labelNames = [];
     this.categoryMap = new Map();
-    this.existingAssetMap = new Map();
+    this.existingAssetIdMap = new Map();
     this.newAssetMetadataMap = new Map();
     this.labelNameIdMap = new Map();
     this.assetLabelValueMap;
@@ -25,6 +25,7 @@ class ImportAssetMetadata extends ImportClass {
     this.tempAttrValuesToUpdate = [];
     this.tempAttrValuesToInsert =[];
     this.CDNBaseUrlLabelMap = new Map();
+    this.newAssetIdMap = new Map();
 
     this.start();
   }
@@ -38,11 +39,14 @@ class ImportAssetMetadata extends ImportClass {
       await this.populateLabelNameIdMap();
       await this.populateCategoryMap();
       await this.populateExistingAssetMap();
-      await this.populateDigitalAssetAttributeValues();
-      await this.updateExistingAssets();
+      await this.populateDigitalAssetAttributeValues(this.existingAssetIdMap);
+      await this.updateExistingAssetsAttributeValues();
       await this.populateCDNBaseUrlLabelMap();
       await this.populateNewAssetList();
       await this.createNewAssets();
+      await this.populateNewAssetMap();
+      await this.populateDigitalAssetAttributeValues(this.newAssetIdMap);
+      await this.updateNewAssetsAttributeValues();
     }
 
     // finish up
@@ -55,7 +59,7 @@ class ImportAssetMetadata extends ImportClass {
         if (!node.digital_asset_id || !node.digital_asset_id.length) {
           throw new Error('Import aborted: digital_asset_id column is missing or has missing values');
         }
-        this.assetNames.push(`'${node.digital_asset_id}'`);
+        this.existingAssetNames.push(`'${node.digital_asset_id}'`);
       }
     } catch (error) {
       this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
@@ -89,33 +93,33 @@ class ImportAssetMetadata extends ImportClass {
   // get a Map of <Digital Asset Name => Digital_Asset__c Id> for assets that already exist in PIM
   async populateExistingAssetMap() {
     const pimAssets = new PimAsset(this.helper, this.log, [
-      ...this.assetNames,
+      ...this.existingAssetNames,
       ...this.parentNames
     ]);
     await pimAssets.populate();
-    this.existingAssetMap = pimAssets.getNameMap();
+    this.existingAssetIdMap = pimAssets.getNameMap();
   }
 
-  async populateDigitalAssetAttributeValues() {
+  async populateDigitalAssetAttributeValues(assetIdMap) {
     if (!this.labelNames.length) {
       return;
     }
     const pimAttributeValue = new PimAttributeValue(this.helper, this.log, []);
     await pimAttributeValue.populateWithDigitalAssetValues(
-      prepareIdsForSOQL(Array.from(this.existingAssetMap.values())), 
+      prepareIdsForSOQL(Array.from(assetIdMap.values())), 
       this.labelNames
     );
     this.assetLabelValueMap = pimAttributeValue.sortAccordingToDigitalAssetAndLabel();
   }
 
-  async updateExistingAssets() {
+  async updateExistingAssetsAttributeValues() {
     try {
       for (let x = 0; x < this.propelParser.nodes.length; x++) {
         if (
           this.propelParser.nodes[x].digital_asset_id &&
-          this.existingAssetMap.has(this.propelParser.nodes[x].digital_asset_id)
+          this.existingAssetIdMap.has(this.propelParser.nodes[x].digital_asset_id)
         ) {
-          const assetSObjectId = this.existingAssetMap.get(this.propelParser.nodes[x].digital_asset_id);
+          const assetSObjectId = this.existingAssetIdMap.get(this.propelParser.nodes[x].digital_asset_id);
           this.updateAssetCategory(assetSObjectId, this.propelParser.nodes[x]);
           
           this.labelNames.forEach((label) => {
@@ -176,7 +180,7 @@ class ImportAssetMetadata extends ImportClass {
   async populateNewAssetList() {
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
       if (!this.propelParser.nodes[x].digital_asset_id ||
-        this.existingAssetMap.has(this.propelParser.nodes[x].digital_asset_id) ||
+        this.existingAssetIdMap.has(this.propelParser.nodes[x].digital_asset_id) ||
         !this.propelParser.nodes[x].cdn_url ||
         !this.isCDNSupported(this.propelParser.nodes[x].cdn_url)) {
           continue;
@@ -267,6 +271,50 @@ class ImportAssetMetadata extends ImportClass {
         throw new Error('invalid CDN url, did you omit the https:// at the start?');
       }
       return 'https://' + url.split('/')[2] + '/';
+    } catch (error) {
+      this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
+      console.log(error);
+    }
+  }
+
+  async populateNewAssetMap() {
+    if (!this.newAssetMetadataMap.size) {
+      return;
+    }
+    const pimAssets = new PimAsset(this.helper, this.log, [
+      ...Array.from(this.newAssetMetadataMap.keys()),
+      ...this.parentNames
+    ]);
+    await pimAssets.populate();
+    this.newAssetIdMap = pimAssets.getNameMap();
+  }
+
+  async updateNewAssetsAttributeValues() {
+    try {
+      for (let x = 0; x < this.propelParser.nodes.length; x++) {
+        if (
+          !this.propelParser.nodes[x].digital_asset_id ||
+          !this.newAssetMetadataMap.has(this.propelParser.nodes[x].digital_asset_id)
+        ) {
+          continue;
+        }
+        this.tempAttrValuesToUpdate = [];
+        this.tempAttrValuesToInsert = [];
+        const assetSObjectId = this.newAssetIdMap.get(this.propelParser.nodes[x].digital_asset_id);
+        this.labelNames.forEach((label) => {
+          label = label.slice(1, -1);
+          this.createTempAttributeValueObjects(label, assetSObjectId, this.propelParser.nodes[x][label]);
+        });
+      }
+      let results = await this.connection.update(
+        this.helper.namespace('Attribute_Value__c'), this.tempAttrValuesToUpdate
+      );
+      this.log.addToLogs(results, this.helper.namespace('Attribute_Value__c'));
+
+      results = await this.connection.insert(
+        this.helper.namespace('Attribute_Value__c'), this.tempAttrValuesToInsert
+      );
+      this.log.addToLogs(results, this.helper.namespace('Attribute_Value__c'));
     } catch (error) {
       this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
       console.log(error);

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -200,33 +200,33 @@ class ImportAssetMetadata extends ImportClass {
       }
 
       let mimeType;
-      let size;
+      let assetSize;
       let request = require("request");
       request({
           url: this.propelParser.nodes[x].cdn_url,
           method: "HEAD"
       }, await function(err, response, body) {
           if (response.headers) {
-            mimeType = response.headers['content-typ'];
-            size = response.headers['content-length'];
+            mimeType = response.headers['content-type'];
+            assetSize = response.headers['content-length'];
           }
-          console.log('size1: ', size);
+          console.log('size1: ', assetSize);
       });
-      console.log('size2: ', size);
+      console.log('size2: ', assetSize);
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
-      console.log('size3: ', size);
+      console.log('size3: ', assetSize);
       if (mimeType) {
         tempAsset['Mime_Type__c'] = mimeType;
       }
-      console.log('size4: ', size);
-      if (size) {
+      console.log('size4: ', assetSize);
+      if (assetSize) {
         console.log('reach: ');
-        tempAsset['Size__c'] = Number(size);
+        tempAsset['Size__c'] = Number(assetSize);
       }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -211,6 +211,7 @@ class ImportAssetMetadata extends ImportClass {
           }
           if (response.headers && response.headers['content-length']) {
             size = Number(response.headers['content-length']);
+            console.log('size0: ', size);
           }
           console.log('size1: ', size);
           process.exit(0);

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -42,7 +42,7 @@ class ImportAssetMetadata extends ImportClass {
       await this.updateExistingAssets();
       await this.populateCDNBaseUrlLabelMap();
       this.populateNewAssetList();
-      this.createNewAssets();
+      await this.createNewAssets();
     }
 
     // finish up
@@ -183,7 +183,7 @@ class ImportAssetMetadata extends ImportClass {
     });
   }
 
-  createNewAssets() {
+  async createNewAssets() {
     if (!this.newAssetList.length) {
       return;
     }
@@ -205,7 +205,7 @@ class ImportAssetMetadata extends ImportClass {
       request({
           url: this.propelParser.nodes[x].cdn_url,
           method: "HEAD"
-      }, function(err, response, body) {
+      }, await function(err, response, body) {
           if (response.headers) {
             mimeType = response.headers['content-typ'];
             size = response.headers['content-length'];

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -249,6 +249,9 @@ class ImportAssetMetadata extends ImportClass {
         method: "HEAD"
     }, function(err, response, body) {
         if (response.headers) {
+          console.log(response.headers);
+          console.log(response.headers['content-type']);
+          console.log(response.headers['content-length']);
           return {
             mimeType: response.headers['content-type'],
             assetSize: response.headers['content-length']

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -18,7 +18,7 @@ class ImportAssetMetadata extends ImportClass {
     this.labelNames = [];
     this.categoryMap = new Map();
     this.existingAssetMap = new Map();
-    this.newAssetList = [];
+    this.newAssetMetadataMap = new Map();
     this.labelNameIdMap = new Map();
     this.assetLabelValueMap;
     this.tempAssetsToUpdate = [];
@@ -41,7 +41,7 @@ class ImportAssetMetadata extends ImportClass {
       await this.populateDigitalAssetAttributeValues();
       await this.updateExistingAssets();
       await this.populateCDNBaseUrlLabelMap();
-      this.populateNewAssetList();
+      await this.populateNewAssetList();
       await this.createNewAssets();
     }
 
@@ -174,48 +174,41 @@ class ImportAssetMetadata extends ImportClass {
   }  
 
   // store a list of asset names for assets that dont exist in PIM
-  populateNewAssetList() {
-    this.assetNames.forEach(assetName => {
-      assetName = assetName.slice(1, -1);
-      if (!this.existingAssetMap.has(assetName)) {
-        this.newAssetList.push(assetName);
-      }
-    });
+  async populateNewAssetList() {
+    for (let x = 0; x < this.propelParser.nodes.length; x++) {
+      if (!this.propelParser.nodes[x].digital_asset_id ||
+        this.existingAssetMap.has(this.propelParser.nodes[x].digital_asset_id) ||
+        !this.propelParser.nodes[x].cdn_url ||
+        !this.isCDNSupported(this.propelParser.nodes[x].cdn_url)) {
+          continue;
+        }
+      this.newAssetMetadataMap.set(
+        this.propelParser.nodes[x].digital_asset_id, 
+        await this.getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)
+      );
+      console.log('this.newAssetMetadataMap: ', this.newAssetMetadataMap)
+    }
   }
 
   async createNewAssets() {
-    if (!this.newAssetList.length) {
+    if (!this.newAssetMetadataMap.size()) {
       return;
     }
     let tempAsset;
     let tempAssetsToInsert = [];
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
-      if (
-        !this.propelParser.nodes[x].digital_asset_id ||
-        !this.newAssetList.includes(this.propelParser.nodes[x].digital_asset_id) ||
-        !this.propelParser.nodes[x].cdn_url ||
-        !this.isCDNSupported(this.propelParser.nodes[x].cdn_url)
-      ) {
+      if (!this.newAssetMetadataMap.has(this.propelParser.nodes[x].digital_asset_id)) {
         continue;
       }
 
-      let { mimeType, assetSize } = await this.getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)
-      console.log('size2: ', assetSize);
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
-      console.log('size3: ', assetSize);
-      if (mimeType) {
-        tempAsset['Mime_Type__c'] = mimeType;
-      }
-      console.log('size4: ', assetSize);
-      if (assetSize) {
-        console.log('reach: ');
-        tempAsset['Size__c'] = Number(assetSize);
-      }
+      tempAsset['Mime_Type__c'] = newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).mimeType;
+      tempAsset['Size__c'] = newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).assetSize;
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  
         if (i < 3) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -170,6 +170,7 @@ class ImportAssetMetadata extends ImportClass {
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
   //  this.CDNBaseUrlLabelMap = await this.getCDNBaseUrlLabelMap();
+    this.CDNBaseUrlLabelMap = new Map[['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]; // TO DELETE, FOR TESTING PURPOSES ONLY
   }  
 
   // store a list of asset names for assets that dont exist in PIM

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -257,11 +257,11 @@ class ImportAssetMetadata extends ImportClass {
             assetSize: response.headers['content-length']
           }
         }
+        return {
+          mimeType: null,
+          assetSize: null
+        }
     });
-    return {
-      mimeType: null,
-      assetSize: null
-    }
   }
 
   getBaseUrlFromCDNUrl(url) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -179,12 +179,14 @@ class ImportAssetMetadata extends ImportClass {
   // store a list of asset names for assets that dont exist in PIM
   async populateNewAssetList() {
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
-      if (!this.propelParser.nodes[x].digital_asset_id ||
+      if (
+        !this.propelParser.nodes[x].digital_asset_id ||
         this.existingAssetIdMap.has(this.propelParser.nodes[x].digital_asset_id) ||
         !this.propelParser.nodes[x].cdn_url ||
-        !this.isCDNSupported(this.propelParser.nodes[x].cdn_url)) {
-          continue;
-        }
+        !this.isCDNSupported(this.propelParser.nodes[x].cdn_url)
+      ) {
+        continue;
+      }
       this.newAssetMetadataMap.set(
         this.propelParser.nodes[x].digital_asset_id, 
         await this.getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -185,7 +185,6 @@ class ImportAssetMetadata extends ImportClass {
         this.propelParser.nodes[x].digital_asset_id, 
         await this.getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)
       );
-      console.log('this.newAssetMetadataMap: ', this.newAssetMetadataMap)
     }
   }
 
@@ -226,6 +225,7 @@ class ImportAssetMetadata extends ImportClass {
       }
       tempAssetsToInsert.push(tempAsset);
     }
+    console.log('tempAssetsToInsert: ', tempAssetsToInsert)
     // let results = await this.connection.insert(
     //   this.helper.namespace('Digital_Asset__c'), this.tempAssetsToInsert
     // );

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -169,10 +169,7 @@ class ImportAssetMetadata extends ImportClass {
 
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
-    const mymap = await this.getCDNBaseUrlLabelMap();
-    console.log('mymap', mymap);
-    console.log('mymap get', mymap.get('https://d3uk1mqqf9h27x.cloudfront.net/'));
-    this.CDNBaseUrlLabelMap = new Map([['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]); // TO DELETE, FOR TESTING PURPOSES ONLY
+    this.CDNBaseUrlLabelMap = await this.getCDNBaseUrlLabelMap();
   }  
 
   // store a list of asset names for assets that dont exist in PIM

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -192,6 +192,35 @@ class ImportAssetMetadata extends ImportClass {
     }
   }
 
+  isCDNSupported(url) {
+    // url should be {baseUrl}/{pathParameters} e.g. https://d3uk1mqqf9h27x.cloudfront.net/00DHu000001IObVMAW/9adcaab5-966b-4fbf-ba9b-ed716d2ce0cc
+    if (url.split('/').length < 3) {
+      return false;
+    }
+    // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
+    const baseUrl = this.getBaseUrlFromCDNUrl(url);
+    return this.CDNBaseUrlLabelMap.has(baseUrl);
+  }
+
+  async getAssetSizeAndType(url) {
+    return new Promise(function (resolve, reject) {
+      let request = require("request");
+      request({
+          url: url,
+          method: "HEAD"
+      }, function(err, response, body) {
+          if (response.headers) {
+            resolve({ 
+              mimeType: response.headers['content-type'],
+              assetSize: response.headers['content-length']
+            });
+          } else {
+            reject(err);
+          }
+      });
+    });
+  }
+
   async createNewAssets() {
     if (!this.newAssetMetadataMap.size) {
       return;
@@ -234,35 +263,6 @@ class ImportAssetMetadata extends ImportClass {
       this.helper.namespace('Digital_Asset__c'), tempAssetsToInsert
     );
     this.log.addToLogs(results, this.helper.namespace('Digital_Asset__c'));
-  }
-
-  isCDNSupported(url) {
-    // url should be {baseUrl}/{pathParameters} e.g. https://d3uk1mqqf9h27x.cloudfront.net/00DHu000001IObVMAW/9adcaab5-966b-4fbf-ba9b-ed716d2ce0cc
-    if (url.split('/').length < 3) {
-      return false;
-    }
-    // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
-    const baseUrl = this.getBaseUrlFromCDNUrl(url);
-    return this.CDNBaseUrlLabelMap.has(baseUrl);
-  }
-
-  async getAssetSizeAndType(url) {
-    return new Promise(function (resolve, reject) {
-      let request = require("request");
-      request({
-          url: url,
-          method: "HEAD"
-      }, function(err, response, body) {
-          if (response.headers) {
-            resolve({ 
-              mimeType: response.headers['content-type'],
-              assetSize: response.headers['content-length']
-            });
-          } else {
-            reject(err);
-          }
-      });
-    });
   }
 
   getBaseUrlFromCDNUrl(url) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -191,7 +191,7 @@ class ImportAssetMetadata extends ImportClass {
   }
 
   async createNewAssets() {
-    if (!this.newAssetMetadataMap.size()) {
+    if (!this.newAssetMetadataMap.size) {
       return;
     }
     let tempAsset;

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -189,7 +189,6 @@ class ImportAssetMetadata extends ImportClass {
     }
     let tempAsset;
     let tempAssetsToInsert = [];
-    console.log('reached');
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
       if (
         !this.propelParser.nodes[x].digital_asset_id ||
@@ -199,6 +198,18 @@ class ImportAssetMetadata extends ImportClass {
       ) {
         continue;
       }
+
+      let request = require("request");
+      request({
+          url: this.propelParser.nodes[x].cdn_url,
+          method: "HEAD"
+      }, function(err, response, body) {
+          console.log('response.headers: ',response.headers);
+          console.log('err: ',err);
+          console.log('body: ',body);
+          process.exit(0);
+      });
+
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
@@ -228,8 +239,6 @@ class ImportAssetMetadata extends ImportClass {
     }
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
     const baseUrl = this.getBaseUrlFromCDNUrl(url);
-    console.log('baseUrl: ', baseUrl)
-    console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(baseUrl))
     return this.CDNBaseUrlLabelMap.has(baseUrl);
   }
 

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -230,7 +230,7 @@ class ImportAssetMetadata extends ImportClass {
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
     const baseUrl = 'https://' + url.split('/')[2];
     console.log('baseUrl: ', baseUrl)
-    console.log('this.CDNBaseUrlLabelMap: ', this.CDNBaseUrlLabelMap)
+    console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(baseUrl))
     return this.CDNBaseUrlLabelMap.has(baseUrl);
   }
 }

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -203,7 +203,8 @@ class ImportAssetMetadata extends ImportClass {
       tempAsset = new Object();
       tempAsset['Name'] = assetName;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
-      tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
+      tempAsset['External_File_Id__c'] = 'N.A.';
+      tempAsset['Content_Location__c'] = this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
       if (this.newAssetMetadataMap.get(assetName) && this.newAssetMetadataMap.get(assetName).mimeType) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -170,7 +170,8 @@ class ImportAssetMetadata extends ImportClass {
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
     const mymap = await this.getCDNBaseUrlLabelMap();
-    console.log(mymap.get('https://d3uk1mqqf9h27x.cloudfront.net/'));
+    console.log('mymap', mymap);
+    console.log('mymap get', mymap.get('https://d3uk1mqqf9h27x.cloudfront.net/'));
     this.CDNBaseUrlLabelMap = new Map([['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]); // TO DELETE, FOR TESTING PURPOSES ONLY
   }  
 

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -228,10 +228,10 @@ class ImportAssetMetadata extends ImportClass {
       return;
     }
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
-    const baseUrl = 'https://' + url.split('/')[2];
+    const baseUrl = 'https://' + url.split('/')[2] + '/';
     console.log('baseUrl: ', baseUrl)
-    console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(`'${baseUrl}'`))
-    return this.CDNBaseUrlLabelMap.has(`'${baseUrl}'`);
+    console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(baseUrl))
+    return this.CDNBaseUrlLabelMap.has(baseUrl);
   }
 }
 module.exports = ImportAssetMetadata;

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -212,7 +212,7 @@ class ImportAssetMetadata extends ImportClass {
         tempAsset['Mime_Type__c'] = this.newAssetMetadataMap.get(assetName).mimeType;
       }
       if (this.newAssetMetadataMap.get(assetName) && this.newAssetMetadataMap.get(assetName).assetSize) {
-        tempAsset['Size__c'] = this.newAssetMetadataMap.get(assetName).assetSize;
+        tempAsset['Size__c'] = Number(this.newAssetMetadataMap.get(assetName).assetSize);
       }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -199,11 +199,10 @@ class ImportAssetMetadata extends ImportClass {
       ) {
         continue;
       }
-      console.log('this.propelParser.nodes[x].digital_asset_id: ', this.propelParser.nodes[x].digital_asset_id)
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
-      tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(this.propelParser.nodes[x].cdn_url);// identifier used to identify CDN
+      tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url));// identifier used to identify CDN
       tempAsset['Mime_Type__c'] = 'bla'; // file type
       tempAsset['Size__c']  = 0; // file size
       tempAsset['View_Link__c'] = ''; //CDN url without the CDN's base url
@@ -225,13 +224,25 @@ class ImportAssetMetadata extends ImportClass {
   isCDNSupported(url) {
     // url should be {baseUrl}/{pathParameters} e.g. https://d3uk1mqqf9h27x.cloudfront.net/00DHu000001IObVMAW/9adcaab5-966b-4fbf-ba9b-ed716d2ce0cc
     if (url.split('/').length < 3) {
-      return;
+      return false;
     }
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
-    const baseUrl = 'https://' + url.split('/')[2] + '/';
+    const baseUrl = this.getBaseUrlFromCDNUrl(url);
     console.log('baseUrl: ', baseUrl)
     console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(baseUrl))
     return this.CDNBaseUrlLabelMap.has(baseUrl);
+  }
+
+  getBaseUrlFromCDNUrl(url) {
+    try {
+      if (url.split('/').length < 3) {
+        throw new Error('invalid CDN url, did you omit the https:// at the start?');
+      }
+      return 'https://' + url.split('/')[2] + '/';
+    } catch (error) {
+      this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
+      console.log(error);
+    }
   }
 }
 module.exports = ImportAssetMetadata;

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -189,6 +189,7 @@ class ImportAssetMetadata extends ImportClass {
     }
     let tempAsset;
     let tempAssetsToInsert = [];
+    console.log('reached');
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
       if (
         !this.propelParser.nodes[x].digital_asset_id ||
@@ -198,6 +199,7 @@ class ImportAssetMetadata extends ImportClass {
       ) {
         continue;
       }
+      console.log('this.propelParser.nodes[x].digital_asset_id: ', this.propelParser.nodes[x].digital_asset_id)
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
@@ -227,6 +229,8 @@ class ImportAssetMetadata extends ImportClass {
     }
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
     const baseUrl = 'https://' + url.split('/')[2];
+    console.log('baseUrl: ', baseUrl)
+    console.log('this.CDNBaseUrlLabelMap: ', this.CDNBaseUrlLabelMap)
     return this.CDNBaseUrlLabelMap.has(baseUrl);
   }
 }

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -291,6 +291,7 @@ class ImportAssetMetadata extends ImportClass {
 
   async updateNewAssetsAttributeValues() {
     try {
+      this.tempAttrValuesToInsert = [];
       for (let x = 0; x < this.propelParser.nodes.length; x++) {
         if (
           !this.propelParser.nodes[x].digital_asset_id ||
@@ -298,19 +299,13 @@ class ImportAssetMetadata extends ImportClass {
         ) {
           continue;
         }
-        this.tempAttrValuesToUpdate = [];
-        this.tempAttrValuesToInsert = [];
         const assetSObjectId = this.newAssetIdMap.get(this.propelParser.nodes[x].digital_asset_id);
         this.labelNames.forEach((label) => {
           label = label.slice(1, -1);
           this.createTempAttributeValueObjects(label, assetSObjectId, this.propelParser.nodes[x][label]);
         });
       }
-      let results = await this.connection.update(
-        this.helper.namespace('Attribute_Value__c'), this.tempAttrValuesToUpdate
-      );
-      this.log.addToLogs(results, this.helper.namespace('Attribute_Value__c'));
-
+      console.log('this.tempAttrValuesToInsert: ', this.tempAttrValuesToInsert)
       results = await this.connection.insert(
         this.helper.namespace('Attribute_Value__c'), this.tempAttrValuesToInsert
       );

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -197,18 +197,23 @@ class ImportAssetMetadata extends ImportClass {
     let tempAsset;
     let tempAssetsToInsert = [];
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
-      if (!this.newAssetMetadataMap.has(this.propelParser.nodes[x].digital_asset_id)) {
+      const assetName = this.propelParser.nodes[x].digital_asset_id;
+      if (!this.newAssetMetadataMap.has(assetName)) {
         continue;
       }
 
       tempAsset = new Object();
-      tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
+      tempAsset['Name'] = assetName;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
-      // tempAsset['Mime_Type__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).mimeType;
-      // tempAsset['Size__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).assetSize;
+      if (this.newAssetMetadataMap.get(assetName) && this.newAssetMetadataMap.get(assetName).mimeType) {
+        tempAsset['Mime_Type__c'] = this.newAssetMetadataMap.get(assetName).mimeType;
+      }
+      if (this.newAssetMetadataMap.get(assetName) && this.newAssetMetadataMap.get(assetName).assetSize) {
+        tempAsset['Size__c'] = this.newAssetMetadataMap.get(assetName).assetSize;
+      }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  
         if (i < 3) {
@@ -243,10 +248,6 @@ class ImportAssetMetadata extends ImportClass {
           method: "HEAD"
       }, function(err, response, body) {
           if (response.headers) {
-            // return {
-            //   mimeType: response.headers['content-type'],
-            //   assetSize: response.headers['content-length']
-            // }
             resolve({ 
               mimeType: response.headers['content-type'],
               assetSize: response.headers['content-length']
@@ -254,10 +255,6 @@ class ImportAssetMetadata extends ImportClass {
           } else {
             reject(err);
           }
-          // return {
-          //   mimeType: null,
-          //   assetSize: null
-          // }
       });
     });
   }

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -170,7 +170,7 @@ class ImportAssetMetadata extends ImportClass {
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
   //  this.CDNBaseUrlLabelMap = await this.getCDNBaseUrlLabelMap();
-    this.CDNBaseUrlLabelMap = new Map[['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]; // TO DELETE, FOR TESTING PURPOSES ONLY
+    this.CDNBaseUrlLabelMap = new Map([['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]); // TO DELETE, FOR TESTING PURPOSES ONLY
   }  
 
   // store a list of asset names for assets that dont exist in PIM

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -281,9 +281,7 @@ class ImportAssetMetadata extends ImportClass {
     if (!this.newAssetMetadataMap.size) {
       return;
     }
-    console.log('this.newAssetMetadataMap: ', this.newAssetMetadataMap)
     let newAssetNames = Array.from(this.newAssetMetadataMap.keys()).map((name) => `'${name}'`);
-    console.log('newAssetNames: ', newAssetNames)
     const pimAssets = new PimAsset(this.helper, this.log, [
       ...newAssetNames,
       ...this.parentNames
@@ -294,7 +292,6 @@ class ImportAssetMetadata extends ImportClass {
 
   async updateNewAssetsAttributeValues() {
     try {
-      console.log('this.newAssetIdMap: ', this.newAssetIdMap)
       this.tempAttrValuesToInsert = [];
       for (let x = 0; x < this.propelParser.nodes.length; x++) {
         if (
@@ -309,7 +306,6 @@ class ImportAssetMetadata extends ImportClass {
           this.createTempAttributeValueObjects(label, assetSObjectId, this.propelParser.nodes[x][label]);
         });
       }
-      console.log('this.tempAttrValuesToInsert: ', this.tempAttrValuesToInsert)
       let results = await this.connection.insert(
         this.helper.namespace('Attribute_Value__c'), this.tempAttrValuesToInsert
       );

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -281,6 +281,8 @@ class ImportAssetMetadata extends ImportClass {
     if (!this.newAssetMetadataMap.size) {
       return;
     }
+    console.log('this.newAssetMetadataMap: ', this.newAssetMetadataMap)
+    console.log('Array.from(this.newAssetMetadataMap.keys()): ', Array.from(this.newAssetMetadataMap.keys()))
     const pimAssets = new PimAsset(this.helper, this.log, [
       ...Array.from(this.newAssetMetadataMap.keys()),
       ...this.parentNames
@@ -291,6 +293,7 @@ class ImportAssetMetadata extends ImportClass {
 
   async updateNewAssetsAttributeValues() {
     try {
+      console.log('this.newAssetIdMap: ', this.newAssetIdMap)
       this.tempAttrValuesToInsert = [];
       for (let x = 0; x < this.propelParser.nodes.length; x++) {
         if (
@@ -306,7 +309,7 @@ class ImportAssetMetadata extends ImportClass {
         });
       }
       console.log('this.tempAttrValuesToInsert: ', this.tempAttrValuesToInsert)
-      results = await this.connection.insert(
+      let results = await this.connection.insert(
         this.helper.namespace('Attribute_Value__c'), this.tempAttrValuesToInsert
       );
       this.log.addToLogs(results, this.helper.namespace('Attribute_Value__c'));

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -199,31 +199,35 @@ class ImportAssetMetadata extends ImportClass {
         continue;
       }
 
-      let request = require("request");
       let mimeType;
       let size;
+      let request = require("request");
       request({
           url: this.propelParser.nodes[x].cdn_url,
           method: "HEAD"
       }, function(err, response, body) {
+          console.log(response.headers);
           if (response.headers && response.headers['content-type']) {
             mimeType = response.headers['content-type'];
           }
           if (response.headers && response.headers['content-length']) {
             size = response.headers['content-length'];
           }
+          console.log('size: ', size);
           process.exit(0);
       });
 
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
-      tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url));// identifier used to identify CDN
+      tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
+        this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
+      );
       if (mimeType) {
         tempAsset['Mime_Type__c'] = mimeType;
       }
       if (size) {
-        tempAsset['Size__c']  = size;
+        tempAsset['Size__c'] = size;
       }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -242,16 +242,15 @@ class ImportAssetMetadata extends ImportClass {
           url: url,
           method: "HEAD"
       }, function(err, response, body) {
-        console.log('url: ', url);
           if (response.headers) {
-            console.log(response.headers);
-            console.log(response.headers['content-type']);
-            console.log(response.headers['content-length']);
             // return {
             //   mimeType: response.headers['content-type'],
             //   assetSize: response.headers['content-length']
             // }
-            resolve(response.headers);
+            resolve({ 
+              mimeType: response.headers['content-type'],
+              assetSize: response.headers['content-length']
+            });
           } else {
             reject(err);
           }

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -206,14 +206,12 @@ class ImportAssetMetadata extends ImportClass {
           url: this.propelParser.nodes[x].cdn_url,
           method: "HEAD"
       }, function(err, response, body) {
-          console.log(response.headers);
           if (response.headers && response.headers['content-type']) {
             mimeType = response.headers['content-type'];
           }
           if (response.headers && response.headers['content-length']) {
             size = response.headers['content-length'];
           }
-          console.log('size: ', size);
           process.exit(0);
       });
 
@@ -226,8 +224,10 @@ class ImportAssetMetadata extends ImportClass {
       if (mimeType) {
         tempAsset['Mime_Type__c'] = mimeType;
       }
+      console.log('size: ', size);
       if (size) {
-        tempAsset['Size__c'] = size;
+        console.log('reach: ');
+        tempAsset['Size__c'] = Number(size);
       }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -199,19 +199,7 @@ class ImportAssetMetadata extends ImportClass {
         continue;
       }
 
-      let mimeType;
-      let assetSize;
-      let request = require("request");
-      request({
-          url: this.propelParser.nodes[x].cdn_url,
-          method: "HEAD"
-      }, await function(err, response, body) {
-          if (response.headers) {
-            mimeType = response.headers['content-type'];
-            assetSize = response.headers['content-length'];
-          }
-          console.log('size1: ', assetSize);
-      });
+      let { mimeType, assetSize } = await getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)
       console.log('size2: ', assetSize);
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
@@ -252,6 +240,25 @@ class ImportAssetMetadata extends ImportClass {
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
     const baseUrl = this.getBaseUrlFromCDNUrl(url);
     return this.CDNBaseUrlLabelMap.has(baseUrl);
+  }
+
+  getAssetSizeAndType(url) {
+    let request = require("request");
+    request({
+        url: url,
+        method: "HEAD"
+    }, function(err, response, body) {
+        if (response.headers) {
+          return {
+            mimeType: response.headers['content-type'],
+            assetSize: response.headers['content-length']
+          }
+        }
+    });
+    return {
+      mimeType: null,
+      assetSize: null
+    }
   }
 
   getBaseUrlFromCDNUrl(url) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -207,8 +207,8 @@ class ImportAssetMetadata extends ImportClass {
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
-      tempAsset['Mime_Type__c'] = newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).mimeType;
-      tempAsset['Size__c'] = newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).assetSize;
+      tempAsset['Mime_Type__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).mimeType;
+      tempAsset['Size__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).assetSize;
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  
         if (i < 3) {
@@ -241,6 +241,7 @@ class ImportAssetMetadata extends ImportClass {
         url: url,
         method: "HEAD"
     }, function(err, response, body) {
+      console.log('url: ', url);
         if (response.headers) {
           console.log(response.headers);
           console.log(response.headers['content-type']);

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -200,13 +200,18 @@ class ImportAssetMetadata extends ImportClass {
       }
 
       let request = require("request");
+      let mimeType;
+      let size;
       request({
           url: this.propelParser.nodes[x].cdn_url,
           method: "HEAD"
       }, function(err, response, body) {
-          console.log('response.headers: ',response.headers);
-          console.log('err: ',err);
-          console.log('body: ',body);
+          if (response.headers && response.headers['content-type']) {
+            mimeType = response.headers['content-type'];
+          }
+          if (response.headers && response.headers['content-length']) {
+            size = response.headers['content-length'];
+          }
           process.exit(0);
       });
 
@@ -214,9 +219,13 @@ class ImportAssetMetadata extends ImportClass {
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url));// identifier used to identify CDN
-      tempAsset['Mime_Type__c'] = 'bla'; // file type
-      tempAsset['Size__c']  = 0; // file size
-      tempAsset['View_Link__c'] = ''; //CDN url without the CDN's base url
+      if (mimeType) {
+        tempAsset['Mime_Type__c'] = mimeType;
+      }
+      if (size) {
+        tempAsset['Size__c']  = size;
+      }
+      tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  
         if (i < 3) {
           // skip baseUrl e.g. https://d3uk1mqqf9h27x.cloudfront.net/

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -199,7 +199,7 @@ class ImportAssetMetadata extends ImportClass {
         continue;
       }
 
-      let { mimeType, assetSize } = await getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)
+      let { mimeType, assetSize } = await this.getAssetSizeAndType(this.propelParser.nodes[x].cdn_url)
       console.log('size2: ', assetSize);
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -169,7 +169,7 @@ class ImportAssetMetadata extends ImportClass {
 
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
-    await this.getCDNBaseUrlLabelMap();
+    console.log(await this.getCDNBaseUrlLabelMap().get('https://d3uk1mqqf9h27x.cloudfront.net/'));
     this.CDNBaseUrlLabelMap = new Map([['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]); // TO DELETE, FOR TESTING PURPOSES ONLY
   }  
 

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -235,12 +235,12 @@ class ImportAssetMetadata extends ImportClass {
     return this.CDNBaseUrlLabelMap.has(baseUrl);
   }
 
-  getAssetSizeAndType(url) {
+  async getAssetSizeAndType(url) {
     let request = require("request");
     request({
         url: url,
         method: "HEAD"
-    }, function(err, response, body) {
+    }, await function(err, response, body) {
       console.log('url: ', url);
         if (response.headers) {
           console.log(response.headers);

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -226,7 +226,7 @@ class ImportAssetMetadata extends ImportClass {
       tempAssetsToInsert.push(tempAsset);
     }
     let results = await this.connection.insert(
-      this.helper.namespace('Digital_Asset__c'), this.tempAssetsToInsert
+      this.helper.namespace('Digital_Asset__c'), tempAssetsToInsert
     );
     this.log.addToLogs(results, this.helper.namespace('Digital_Asset__c'));
   }

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -207,7 +207,7 @@ class ImportAssetMetadata extends ImportClass {
           method: "HEAD"
       }, function(err, response, body) {
           if (response.headers) {
-            mimeType = response.headers['content-type'];
+            mimeType = response.headers['content-typ'];
             size = response.headers['content-length'];
           }
           console.log('size1: ', size);

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -214,7 +214,6 @@ class ImportAssetMetadata extends ImportClass {
             console.log('size0: ', size);
           }
           console.log('size1: ', size);
-          process.exit(0);
       });
       console.log('size2: ', size);
       tempAsset = new Object();

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -230,8 +230,8 @@ class ImportAssetMetadata extends ImportClass {
     // e.g. https:// + d3uk1mqqf9h27x.cloudfront.net/
     const baseUrl = 'https://' + url.split('/')[2];
     console.log('baseUrl: ', baseUrl)
-    console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(baseUrl))
-    return this.CDNBaseUrlLabelMap.has(baseUrl);
+    console.log('this.CDNBaseUrlLabelMap.has(baseUrl): ', this.CDNBaseUrlLabelMap.has(`'${baseUrl}'`))
+    return this.CDNBaseUrlLabelMap.has(`'${baseUrl}'`);
   }
 }
 module.exports = ImportAssetMetadata;

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -206,12 +206,9 @@ class ImportAssetMetadata extends ImportClass {
           url: this.propelParser.nodes[x].cdn_url,
           method: "HEAD"
       }, function(err, response, body) {
-          if (response.headers && response.headers['content-type']) {
+          if (response.headers) {
             mimeType = response.headers['content-type'];
-          }
-          if (response.headers && response.headers['content-length']) {
-            size = Number(response.headers['content-length']);
-            console.log('size0: ', size);
+            size = response.headers['content-length'];
           }
           console.log('size1: ', size);
       });
@@ -229,7 +226,7 @@ class ImportAssetMetadata extends ImportClass {
       console.log('size4: ', size);
       if (size) {
         console.log('reach: ');
-        tempAsset['Size__c'] = size;
+        tempAsset['Size__c'] = Number(size);
       }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -169,7 +169,7 @@ class ImportAssetMetadata extends ImportClass {
 
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
-  //  this.CDNBaseUrlLabelMap = await this.getCDNBaseUrlLabelMap();
+    await this.getCDNBaseUrlLabelMap();
     this.CDNBaseUrlLabelMap = new Map([['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]); // TO DELETE, FOR TESTING PURPOSES ONLY
   }  
 
@@ -226,8 +226,11 @@ class ImportAssetMetadata extends ImportClass {
         tempAsset['View_Link__c'] += this.propelParser.nodes[x].cdn_url.split('/')[i];
       }
       tempAssetsToInsert.push(tempAsset);
-      console.log('tempAsset": ', tempAsset)
     }
+    // let results = await this.connection.insert(
+    //   this.helper.namespace('Digital_Asset__c'), this.tempAssetsToInsert
+    // );
+    // this.log.addToLogs(results, this.helper.namespace('Digital_Asset__c'));
   }
 
   isCDNSupported(url) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -210,24 +210,26 @@ class ImportAssetMetadata extends ImportClass {
             mimeType = response.headers['content-type'];
           }
           if (response.headers && response.headers['content-length']) {
-            size = response.headers['content-length'];
+            size = Number(response.headers['content-length']);
           }
+          console.log('size1: ', size);
           process.exit(0);
       });
-
+      console.log('size2: ', size);
       tempAsset = new Object();
       tempAsset['Name'] = this.propelParser.nodes[x].digital_asset_id;
       tempAsset['Category__c'] = this.categoryMap.get(this.propelParser.nodes[x].category_id);
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
+      console.log('size3: ', size);
       if (mimeType) {
         tempAsset['Mime_Type__c'] = mimeType;
       }
-      console.log('size: ', size);
+      console.log('size4: ', size);
       if (size) {
         console.log('reach: ');
-        tempAsset['Size__c'] = Number(size);
+        tempAsset['Size__c'] = size;
       }
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -282,9 +282,10 @@ class ImportAssetMetadata extends ImportClass {
       return;
     }
     console.log('this.newAssetMetadataMap: ', this.newAssetMetadataMap)
-    console.log('Array.from(this.newAssetMetadataMap.keys()): ', Array.from(this.newAssetMetadataMap.keys()))
+    let newAssetNames = Array.from(this.newAssetMetadataMap.keys()).map((name) => `'${name}'`);
+    console.log('newAssetNames: ', newAssetNames)
     const pimAssets = new PimAsset(this.helper, this.log, [
-      ...Array.from(this.newAssetMetadataMap.keys()),
+      ...newAssetNames,
       ...this.parentNames
     ]);
     await pimAssets.populate();

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -169,7 +169,8 @@ class ImportAssetMetadata extends ImportClass {
 
   /** Gets a Map of <CDN base url, CDN label> that we support. Note CDN label will be used as identifier in Digital_Asset__r.Content_Location__c */
   async populateCDNBaseUrlLabelMap() {
-    console.log(await this.getCDNBaseUrlLabelMap().get('https://d3uk1mqqf9h27x.cloudfront.net/'));
+    const mymap = await this.getCDNBaseUrlLabelMap();
+    console.log(mymap.get('https://d3uk1mqqf9h27x.cloudfront.net/'));
     this.CDNBaseUrlLabelMap = new Map([['https://d3uk1mqqf9h27x.cloudfront.net/', 'aws']]); // TO DELETE, FOR TESTING PURPOSES ONLY
   }  
 

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -225,11 +225,10 @@ class ImportAssetMetadata extends ImportClass {
       }
       tempAssetsToInsert.push(tempAsset);
     }
-    console.log('tempAssetsToInsert: ', tempAssetsToInsert)
-    // let results = await this.connection.insert(
-    //   this.helper.namespace('Digital_Asset__c'), this.tempAssetsToInsert
-    // );
-    // this.log.addToLogs(results, this.helper.namespace('Digital_Asset__c'));
+    let results = await this.connection.insert(
+      this.helper.namespace('Digital_Asset__c'), this.tempAssetsToInsert
+    );
+    this.log.addToLogs(results, this.helper.namespace('Digital_Asset__c'));
   }
 
   isCDNSupported(url) {

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -207,8 +207,8 @@ class ImportAssetMetadata extends ImportClass {
       tempAsset['Content_Location__c'] =  this.CDNBaseUrlLabelMap.get(
         this.getBaseUrlFromCDNUrl(this.propelParser.nodes[x].cdn_url)
       );
-      tempAsset['Mime_Type__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).mimeType;
-      tempAsset['Size__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).assetSize;
+      // tempAsset['Mime_Type__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).mimeType;
+      // tempAsset['Size__c'] = this.newAssetMetadataMap.get(this.propelParser.nodes[x].digital_asset_id).assetSize;
       tempAsset['View_Link__c'] = '';
       for (let i = 0; i < this.propelParser.nodes[x].cdn_url.split('/').length; i++) {  
         if (i < 3) {

--- a/lib/ImportClass.js
+++ b/lib/ImportClass.js
@@ -56,7 +56,11 @@ class ImportClass {
   async getCDNBaseUrlLabelMap() {
     try {
       let service = new ForceService(this.response.instance_url, this.response.access_token);
-      return new Map(Object.entries(service.getCDNBaseUrlLabelMap()));
+      const jsonCDNBaseUrlLabelMap = await service.getCDNBaseUrlLabelMap();
+      console.log('jsonCDNBaseUrlLabelMap: ', jsonCDNBaseUrlLabelMap)
+      console.log('Object.entries(jsonCDNBaseUrlLabelMap): ', Object.entries(jsonCDNBaseUrlLabelMap))
+      console.log('new Map(Object.entries(jsonCDNBaseUrlLabelMap)): ', new Map(Object.entries(jsonCDNBaseUrlLabelMap)))
+      return new Map(Object.entries(jsonCDNBaseUrlLabelMap));
     } catch (error) {
       this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
       console.log(error);

--- a/lib/ImportClass.js
+++ b/lib/ImportClass.js
@@ -58,10 +58,8 @@ class ImportClass {
       let service = new ForceService(this.response.instance_url, this.response.access_token);
       const jsonCDNBaseUrlLabelMap = await service.getCDNBaseUrlLabelMap();
       console.log('jsonCDNBaseUrlLabelMap: ', jsonCDNBaseUrlLabelMap)
-      console.log('JSON.parse(jsonCDNBaseUrlLabelMap): ', JSON.parse(jsonCDNBaseUrlLabelMap))
-      console.log('jsonCDNBaseUrlLabelMap["https://www.google.com"]: ', jsonCDNBaseUrlLabelMap["https://www.google.com"])
-      console.log('new Map(Object.entries(jsonCDNBaseUrlLabelMap)): ', new Map(Object.entries(jsonCDNBaseUrlLabelMap)))
-      return new Map(Object.entries(jsonCDNBaseUrlLabelMap));
+      console.log('new Map(Object.entries(JSON.parse(jsonCDNBaseUrlLabelMap))): ', new Map(Object.entries(JSON.parse(jsonCDNBaseUrlLabelMap))))
+      return new Map(Object.entries(JSON.parse(jsonCDNBaseUrlLabelMap)));
     } catch (error) {
       this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
       console.log(error);

--- a/lib/ImportClass.js
+++ b/lib/ImportClass.js
@@ -58,7 +58,8 @@ class ImportClass {
       let service = new ForceService(this.response.instance_url, this.response.access_token);
       const jsonCDNBaseUrlLabelMap = await service.getCDNBaseUrlLabelMap();
       console.log('jsonCDNBaseUrlLabelMap: ', jsonCDNBaseUrlLabelMap)
-      console.log('Object.entries(jsonCDNBaseUrlLabelMap): ', Object.entries(jsonCDNBaseUrlLabelMap))
+      console.log('JSON.parse(jsonCDNBaseUrlLabelMap): ', JSON.parse(jsonCDNBaseUrlLabelMap))
+      console.log('jsonCDNBaseUrlLabelMap["https://www.google.com"]: ', jsonCDNBaseUrlLabelMap["https://www.google.com"])
       console.log('new Map(Object.entries(jsonCDNBaseUrlLabelMap)): ', new Map(Object.entries(jsonCDNBaseUrlLabelMap)))
       return new Map(Object.entries(jsonCDNBaseUrlLabelMap));
     } catch (error) {

--- a/lib/ImportClass.js
+++ b/lib/ImportClass.js
@@ -54,8 +54,13 @@ class ImportClass {
   }
 
   async getCDNBaseUrlLabelMap() {
-    let service = new ForceService(this.response.instance_url, this.response.access_token);
-    service.getCDNBaseUrlLabelMap();
+    try {
+      let service = new ForceService(this.response.instance_url, this.response.access_token);
+      return new Map(Object.entries(service.getCDNBaseUrlLabelMap()));
+    } catch (error) {
+      this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
+      console.log(error);
+    }
   }
 }
 

--- a/lib/ImportClass.js
+++ b/lib/ImportClass.js
@@ -53,6 +53,7 @@ class ImportClass {
     await this.propelParser.parseCsv()
   }
 
+  /** calls APEX REST API to get an convert to javascript Map of supported <CDN Base Url, Label> */
   async getCDNBaseUrlLabelMap() {
     try {
       let service = new ForceService(this.response.instance_url, this.response.access_token);

--- a/lib/ImportClass.js
+++ b/lib/ImportClass.js
@@ -56,10 +56,8 @@ class ImportClass {
   async getCDNBaseUrlLabelMap() {
     try {
       let service = new ForceService(this.response.instance_url, this.response.access_token);
-      const jsonCDNBaseUrlLabelMap = await service.getCDNBaseUrlLabelMap();
-      console.log('jsonCDNBaseUrlLabelMap: ', jsonCDNBaseUrlLabelMap)
-      console.log('new Map(Object.entries(JSON.parse(jsonCDNBaseUrlLabelMap))): ', new Map(Object.entries(JSON.parse(jsonCDNBaseUrlLabelMap))))
-      return new Map(Object.entries(JSON.parse(jsonCDNBaseUrlLabelMap)));
+      const stringifiedCDNBaseUrlLabelMap = await service.getCDNBaseUrlLabelMap();
+      return new Map(Object.entries(JSON.parse(stringifiedCDNBaseUrlLabelMap)));
     } catch (error) {
       this.log.addToLogs([{errors: [error] }], this.helper.namespace('Digital_Asset__c'));
       console.log(error);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -57,7 +57,7 @@ describe('Utils tests', () => {
           reqBody
         );
         sinon.assert.calledOnce(stub);
-        sinon.assert.calledWith(stub, dummy_link, dummyLocation, reqBody);
+        sinon.assert.calledWith(stub, dummy_link, dummy_contentLocation, reqBody);
         assert.equal(daDownloadDetailsList.length, 1);
         assert.equal(parsed, dummy_link);
       });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 describe('Utils tests', () => {
   describe('parseDigitalAssetAttrVal', () => {
     let stub;
+    const dummy_contentLocation = 'dummyLocation';
     const dummy_link = 'dummy_link';
     const attrValValue = 'dummy_attr_val';
     const invalidAttrValValue = 'invalid_dummy_attr_val';
@@ -56,7 +57,7 @@ describe('Utils tests', () => {
           reqBody
         );
         sinon.assert.calledOnce(stub);
-        sinon.assert.calledWith(stub, dummy_link, reqBody);
+        sinon.assert.calledWith(stub, dummy_link, dummyLocation, reqBody);
         assert.equal(daDownloadDetailsList.length, 1);
         assert.equal(parsed, dummy_link);
       });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 describe('Utils tests', () => {
   describe('parseDigitalAssetAttrVal', () => {
     let stub;
-    const dummy_contentLocation = 'dummyLocation';
+    const dummy_contentLocation = 'dummy_location';
     const dummy_link = 'dummy_link';
     const attrValValue = 'dummy_attr_val';
     const invalidAttrValValue = 'invalid_dummy_attr_val';
@@ -45,8 +45,13 @@ describe('Utils tests', () => {
 
       it('not a legit link', async () => {
         const helper = {
-          getValue: () => {
-            return dummy_link;
+          getValue: (asset, field) => {
+            if (field == 'View_Link__c') {
+              return dummy_link;
+            }
+            if (field == 'Content_Location__c') {
+              return dummy_contentLocation;
+            }
           }
         };
         const parsed = await utils.parseDigitalAssetAttrVal(


### PR DESCRIPTION
- get Digital Asset size and mime type from URL provided at import
- get CDN information from PIM
- store CDN identifier as field value at `Digital_Asset__c.Content_Location__c`
- extend product export to support multiple CDNs when constructing the complete CDN URL from the truncated `View_Link__c`
- update the newly created `Digital_Asset__c` with attribute values for attributes specified in import

https://github.com/PropelPLM/pim-data-service/assets/77341283/29a3575e-4b9c-4050-b307-4695047aa2c4


PIM PR: https://github.com/PropelPLM/PIM/pull/1271
