### PR TITLE
PIM-1328: PIM | Export | PLP export with parent only selected and Export lowest option selected will not export lowest variants

### DIFF
--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -58,6 +58,9 @@ async function PimRecordListHelper(
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
+  for (let fr of filteredRecords) {
+    console.log('record id: ' + fr.get('Id'))
+  }
   console.log('recordIds: ' + recordIds)
   console.log('variantValueIds: ' + variantValueIds)
   console.log('filteredRecords length: ' + filteredRecords.length)

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -59,7 +59,7 @@ async function PimRecordListHelper(
   });
   console.log('filteredRecord 0: ' + filteredRecords[0].get('Id'))
   console.log('filteredRecord 1: ' + filteredRecords[1].get('Id'))
-  console.log('filteredRecord 2: ' + filteredRecords[1].get('Parent_ID'))
+  console.log('filteredRecord 2: ' + filteredRecords[2].get('Parent_ID'))
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 
   /** PIM repo ProductService.productStructureByCategory end */

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -90,17 +90,20 @@ async function PimRecordListHelper(
       }
       // get SKUs (lowest variants) of parent products of selected records
       const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
-      //exportRecordsAndColumns[0]
+      exportRecordsAndColumns[0] = await PimRecordService(
+        lowestVariants,
+        helper,
+        service,
+        true
+      )
+      console.log('exportRecordsAndCol[0]: ' + exportRecordsAndColumns[0])
+      console.log('exportRecordsAndCol[0][0]: ' + exportRecordsAndColumns[0][0])
+      console.log('exportRecordsAndCol[0][0].keys: ' + Array.from(exportRecordsAndColumns[0][0].keys()))
       vvIds.clear();
       for (let lowestVariant of lowestVariants) {
-        console.log('id: ' + lowestVariant.Id)
         vvIds.add(lowestVariant.Id)
         recordIdSet.add(helper.getValue(lowestVariant, 'Variant__r.Product__c'));
       }
-      console.log('vvIds: ' + vvIds)
-      console.log('vvIds.size: ' + vvIds.size)
-      console.log('recordIdSet: ' + recordIdSet)
-      console.log('recordIdSet.size: ' + recordIdSet.size)
     }
     //////////////// OLD CODE START
     // if (vvIds.size > 0) {

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -57,9 +57,9 @@ async function PimRecordListHelper(
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
-  console.log('filteredRecord 0: ' + Array.from(filteredRecords[0].get('Id')))
-  console.log('filteredRecord 1: ' + Array.from(filteredRecords[1].get('Id')))
-  console.log('filteredRecord 2: ' + Array.from(filteredRecords[1].get('Parent_ID')))
+  console.log('filteredRecord 0: ' + filteredRecords[0].get('Id'))
+  console.log('filteredRecord 1: ' + filteredRecords[1].get('Id'))
+  console.log('filteredRecord 2: ' + filteredRecords[1].get('Parent_ID'))
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 
   /** PIM repo ProductService.productStructureByCategory end */

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -85,7 +85,7 @@ async function PimRecordListHelper(
       for (let selectedRecord of exportRecordsAndColumns[0]) {
         selectedRecordParentProductId = selectedRecord.get('Parent_ID') ?? selectedRecord.get('Id');
         if (!productsToQueryForSKU.includes(selectedRecordParentProductId)) {
-          productsToQueryForSKU.add(selectedRecordParentProductId);
+          productsToQueryForSKU.push(selectedRecordParentProductId);
         }
       }
       // get SKUs (lowest variants) of parent products of selected records

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -106,6 +106,7 @@ async function PimRecordListHelper(
           variantValues,
           namespace
         );
+        console.log('querylist: ' + service.QUERY_LIST)
         for (let varV of variantValues) {
           console.log('variantValues1: ' + varV)
         }

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -89,9 +89,12 @@ async function PimRecordListHelper(
         }
       }
       // get SKUs (lowest variants) of parent products of selected records
-      exportRecordsAndColumns[0] = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
-      console.log('exportRecords length: ' + exportRecordsAndColumns[0])
+      const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
+      //exportRecordsAndColumns[0]
+      console.log('lowestVariants: ' + lowestVariants)
+      console.log('lowestVariants lem: ' + lowestVariants.length)
     }
+    //////////////// OLD CODE START
     // if (vvIds.size > 0) {
     //   const stringifiedQuotedVariantValueIds = prepareIdsForSOQL(vvIds);
     //   let variantValues = await service.queryExtend(
@@ -128,6 +131,7 @@ async function PimRecordListHelper(
     //     recordIdSet.add(helper.getValue(value, 'Variant__r.Product__c'));
     //   });
     // }
+    /////////////////// OLD CODE END
 
     const recordIdsToQuery = prepareIdsForSOQL(recordIdSet);
     let recordList = await PimRecordManager(

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -96,10 +96,10 @@ async function PimRecordListHelper(
         const tempMap = new Map();
         tempMap.set('Id', lowestVariant.Id);
         tempMap.set('Record_ID', lowestVariant.Name);
-        tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Category__c'));
+        tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__c'));
         tempMap.set(
           'Category__r.Name',
-          helper.getValue(topLevelRecord, 'Category__r').Name
+          helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__r').Name
         );
         tempMap.set(
           'Title',

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -90,12 +90,32 @@ async function PimRecordListHelper(
       }
       // get SKUs (lowest variants) of parent products of selected records
       const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
-      exportRecordsAndColumns[0] = await PimRecordService(
-        lowestVariants,
-        helper,
-        service,
-        true
-      )
+      exportRecordsAndColumns[0] = [];
+      for (let lowestVariant of lowestVariants) {
+        const topLevelRecord = helper.getValue(lowestVariant, 'Variant__r.Product__c');
+        const tempMap = new Map();
+        tempMap.set('Id', lowestVariant.Id);
+        tempMap.set('Record_ID', lowestVariant.Name);
+        tempMap.set('Category__r.Name', 'PLACEHOLDER PLEASE REMOVE')
+        tempMap.set('Category__c', 'PLACEHOLDER PLEASE REMOVE')
+        tempMap.set('Title', 'PLACEHOLDER PLEASE REMOVE')
+        // tempMap.set(
+        //   'Category__r.Name',
+        //   helper.getValue(topLevelRecord, 'Category__r').Name
+        // );
+        // tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Category__c'));
+
+        // if (!parentProduct) return tempMap;
+
+        // tempMap.set(
+        //   'Title',
+        //   helper.getValue(record, 'Label__c')
+        //     ? helper.getValue(record, 'Label__c')
+        //     : record.Name
+        // );
+        tempMap.set('Parent_ID', topLevelRecord.Id);
+        exportRecordsAndColumns[0].push(tempMap);
+      }
       console.log('exportRecordsAndCol[0]: ' + exportRecordsAndColumns[0])
       console.log('exportRecordsAndCol[0][0]: ' + exportRecordsAndColumns[0][0])
       console.log('exportRecordsAndCol[0][0].keys: ' + Array.from(exportRecordsAndColumns[0][0].keys()))

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -91,8 +91,15 @@ async function PimRecordListHelper(
       // get SKUs (lowest variants) of parent products of selected records
       const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
       //exportRecordsAndColumns[0]
-      console.log('lowestVariants: ' + lowestVariants)
-      console.log('lowestVariants lem: ' + lowestVariants.length)
+      vvIds.clear();
+      for (let lowestVariant of lowestVariants) {
+        vvIds.add(lowestVariant.Id)
+        recordIdSet.add(helper.getValue(lowestVariant, 'Variant__r.Product__c'));
+      }
+      console.log('vvIds: ' + vvIds)
+      console.log('vvIds.size: ' + vvIds.size)
+      console.log('recordIdSet: ' + recordIdSet)
+      console.log('recordIdSet.size: ' + recordIdSet.size)
     }
     //////////////// OLD CODE START
     // if (vvIds.size > 0) {

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -99,7 +99,7 @@ async function PimRecordListHelper(
         tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__c'));
         tempMap.set(
           'Category__r.Name',
-          helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__r').Name
+          helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__r.Name')
         );
         tempMap.set(
           'Title',

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -57,8 +57,9 @@ async function PimRecordListHelper(
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
-  console.log('filteredRecord 0: ' + Array.from(filteredRecords[0].keys()))
-  console.log('filteredRecord 1: ' + Array.from(filteredRecords[1].keys()))
+  console.log('filteredRecord 0: ' + Array.from(filteredRecords[0].get('Id')))
+  console.log('filteredRecord 1: ' + Array.from(filteredRecords[1].get('Id')))
+  console.log('filteredRecord 2: ' + Array.from(filteredRecords[1].get('Parent_ID')))
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 
   /** PIM repo ProductService.productStructureByCategory end */

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -58,9 +58,6 @@ async function PimRecordListHelper(
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
-  console.log('filteredRecord 0: ' + filteredRecords[0].get('Id'))
-  console.log('filteredRecord 1: ' + filteredRecords[1].get('Id'))
-  console.log('filteredRecord 2: ' + filteredRecords[2].get('Parent_ID'))
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 
   /** PIM repo ProductService.productStructureByCategory end */

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -54,16 +54,11 @@ async function PimRecordListHelper(
     isSKUExport = exportType === 'lowestVariants';
 
   // filter the records if rows were selected or filters applied in product list page
-  console.log('exportRecords length: ' + exportRecords.length)
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
-  for (let fr of filteredRecords) {
-    console.log('record id: ' + Object.keys(fr))
-  }
-  console.log('recordIds: ' + recordIds)
-  console.log('variantValueIds: ' + variantValueIds)
-  console.log('filteredRecords length: ' + filteredRecords.length)
+  console.log('filteredRecord 0: ' + Array.from(filteredRecords[0].keys()))
+  console.log('filteredRecord 1: ' + Array.from(filteredRecords[1].keys()))
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 
   /** PIM repo ProductService.productStructureByCategory end */
@@ -98,7 +93,7 @@ async function PimRecordListHelper(
 
       let lowestVariantValueIds;
       if (isSKUExport) {
-        // get the lowest level variant values' ids
+        // get the lowest level variant values' ids from a list of variant values
         lowestVariantValueIds = await getLowestVariantValuesList(
           variantValues,
           namespace

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -106,7 +106,7 @@ async function PimRecordListHelper(
           variantValues,
           namespace
         );
-        console.log('querylist: ' + service.QUERY_LIST)
+        console.log('querylist: ' + stringifiedQuotedVariantValueIds.split(','))
         for (let varV of variantValues) {
           console.log('variantValues1: ' + varV)
         }

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -106,10 +106,13 @@ async function PimRecordListHelper(
           variantValues,
           namespace
         );
+        console.log('variantValues1: ' + variantValues)
+        console.log('lowestVariantValueIds: ' + lowestVariantValueIds)
         // filter out all records not selected for export
         variantValues = variantValues.filter(value =>
           lowestVariantValueIds.includes(value.Name)
         );
+        console.log('variantValues2: ' + variantValues)
         exportRecordsAndColumns[0] = exportRecordsAndColumns[0].filter(record =>
           lowestVariantValueIds.includes(record.get('Record_ID'))
         );

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -53,20 +53,10 @@ async function PimRecordListHelper(
     ),
     isSKUExport = exportType === 'lowestVariants';
 
-  let variantsPresentInLowestVariantExport,
-    recordIsPresentInNonLowestVariantExport;
   // filter the records if rows were selected or filters applied in product list page
   console.log('exportRecords length: ' + exportRecords.length)
   let filteredRecords = exportRecords.filter(record => {
-    variantsPresentInLowestVariantExport =
-      isSKUExport && variantValueIds?.includes(record.get('Id'));
-    recordIsPresentInNonLowestVariantExport =
-      (!isSKUExport && recordIds.includes(record.get('Id'))) ||
-      variantValueIds?.includes(record.get('Id'));
-    return (
-      variantsPresentInLowestVariantExport ||
-      recordIsPresentInNonLowestVariantExport
-    );
+    return recordIds.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
   console.log('filteredRecords length: ' + filteredRecords.length)
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -56,6 +56,7 @@ async function PimRecordListHelper(
   let variantsPresentInLowestVariantExport,
     recordIsPresentInNonLowestVariantExport;
   // filter the records if rows were selected or filters applied in product list page
+  console.log('exportRecords length: ' + exportRecords.length)
   let filteredRecords = exportRecords.filter(record => {
     variantsPresentInLowestVariantExport =
       isSKUExport && variantValueIds?.includes(record.get('Id'));
@@ -67,6 +68,7 @@ async function PimRecordListHelper(
       recordIsPresentInNonLowestVariantExport
     );
   });
+  console.log('filteredRecords length: ' + filteredRecords.length)
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 
   /** PIM repo ProductService.productStructureByCategory end */
@@ -106,18 +108,10 @@ async function PimRecordListHelper(
           variantValues,
           namespace
         );
-        console.log('querylist: ' + stringifiedQuotedVariantValueIds.split(','))
-        for (let varV of variantValues) {
-          console.log((util.inspect(varV, false, null, true)))
-        }
-        console.log('lowestVariantValueIds: ' + lowestVariantValueIds)
         // filter out all records not selected for export
         variantValues = variantValues.filter(value =>
           lowestVariantValueIds.includes(value.Name)
         );
-        for (let varV of variantValues) {
-          console.log('variantValues2: ' + varV)
-        }
         exportRecordsAndColumns[0] = exportRecordsAndColumns[0].filter(record =>
           lowestVariantValueIds.includes(record.get('Record_ID'))
         );

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -108,7 +108,7 @@ async function PimRecordListHelper(
         );
         console.log('querylist: ' + stringifiedQuotedVariantValueIds.split(','))
         for (let varV of variantValues) {
-          console.log('variantValues1: ' + varV)
+          console.log((util.inspect(varV, false, null, true)))
         }
         console.log('lowestVariantValueIds: ' + lowestVariantValueIds)
         // filter out all records not selected for export

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -96,16 +96,16 @@ async function PimRecordListHelper(
         const tempMap = new Map();
         tempMap.set('Id', lowestVariant.Id);
         tempMap.set('Record_ID', lowestVariant.Name);
-        tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__c'));
+        tempMap.set('Category__c', helper.getValue(lowestVariant, 'Variant__r.Product__r.Category__c'));
         tempMap.set(
           'Category__r.Name',
-          helper.getValue(topLevelRecord, 'Variant__r.Product__r.Category__r.Name')
+          helper.getValue(lowestVariant, 'Variant__r.Product__r.Category__r.Name')
         );
         tempMap.set(
           'Title',
-          helper.getValue(record, 'Label__c')
-            ? helper.getValue(record, 'Label__c')
-            : record.Name
+          helper.getValue(lowestVariant, 'Label__c')
+            ? helper.getValue(lowestVariant, 'Label__c')
+            : lowestVariant.Name
         );
         tempMap.set('Parent_ID', topLevelRecord);
         exportRecordsAndColumns[0].push(tempMap);

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -56,8 +56,10 @@ async function PimRecordListHelper(
   // filter the records if rows were selected or filters applied in product list page
   console.log('exportRecords length: ' + exportRecords.length)
   let filteredRecords = exportRecords.filter(record => {
-    return recordIds.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
+    return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
+  console.log('recordIds: ' + recordIds)
+  console.log('variantValueIds: ' + variantValueIds)
   console.log('filteredRecords length: ' + filteredRecords.length)
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
 

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -96,24 +96,18 @@ async function PimRecordListHelper(
         const tempMap = new Map();
         tempMap.set('Id', lowestVariant.Id);
         tempMap.set('Record_ID', lowestVariant.Name);
-        tempMap.set('Category__r.Name', 'PLACEHOLDER PLEASE REMOVE')
-        tempMap.set('Category__c', 'PLACEHOLDER PLEASE REMOVE')
-        tempMap.set('Title', 'PLACEHOLDER PLEASE REMOVE')
-        // tempMap.set(
-        //   'Category__r.Name',
-        //   helper.getValue(topLevelRecord, 'Category__r').Name
-        // );
-        // tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Category__c'));
-
-        // if (!parentProduct) return tempMap;
-
-        // tempMap.set(
-        //   'Title',
-        //   helper.getValue(record, 'Label__c')
-        //     ? helper.getValue(record, 'Label__c')
-        //     : record.Name
-        // );
-        tempMap.set('Parent_ID', topLevelRecord.Id);
+        tempMap.set('Category__c', helper.getValue(topLevelRecord, 'Category__c'));
+        tempMap.set(
+          'Category__r.Name',
+          helper.getValue(topLevelRecord, 'Category__r').Name
+        );
+        tempMap.set(
+          'Title',
+          helper.getValue(record, 'Label__c')
+            ? helper.getValue(record, 'Label__c')
+            : record.Name
+        );
+        tempMap.set('Parent_ID', topLevelRecord);
         exportRecordsAndColumns[0].push(tempMap);
       }
       console.log('exportRecordsAndCol[0]: ' + exportRecordsAndColumns[0])

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -93,6 +93,7 @@ async function PimRecordListHelper(
       //exportRecordsAndColumns[0]
       vvIds.clear();
       for (let lowestVariant of lowestVariants) {
+        console.log('id: ' + lowestVariant.Id)
         vvIds.add(lowestVariant.Id)
         recordIdSet.add(helper.getValue(lowestVariant, 'Variant__r.Product__c'));
       }

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -59,7 +59,7 @@ async function PimRecordListHelper(
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
   for (let fr of filteredRecords) {
-    console.log('record id: ' + fr.get('Id'))
+    console.log('record id: ' + Object.keys(fr))
   }
   console.log('recordIds: ' + recordIds)
   console.log('variantValueIds: ' + variantValueIds)

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -5,7 +5,7 @@ const {
   DA_DOWNLOAD_DETAIL_KEY,
   DEFAULT_COLUMNS,
   getLowestVariantsFromProducts,
-  getLowestVariantValuesList,
+  extractLowestVariantValues,
   initAssetDownloadDetailsList,
   prepareIdsForSOQL,
   parseDigitalAssetAttrVal,
@@ -91,27 +91,8 @@ async function PimRecordListHelper(
       // get SKUs (lowest variants) of parent products of selected records
       const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
       exportRecordsAndColumns[0] = await populateRecordDetailsForLowestVariants(lowestVariants);
-      // for (let lowestVariant of lowestVariants) {
-      //   const topLevelRecord = helper.getValue(lowestVariant, 'Variant__r.Product__c');
-      //   const tempMap = new Map();
-      //   tempMap.set('Id', lowestVariant.Id);
-      //   tempMap.set('Record_ID', lowestVariant.Name);
-      //   tempMap.set('Category__c', helper.getValue(lowestVariant, 'Variant__r.Product__r.Category__c'));
-      //   tempMap.set(
-      //     'Category__r.Name',
-      //     helper.getValue(lowestVariant, 'Variant__r.Product__r.Category__r.Name')
-      //   );
-      //   tempMap.set(
-      //     'Title',
-      //     helper.getValue(lowestVariant, 'Label__c')
-      //       ? helper.getValue(lowestVariant, 'Label__c')
-      //       : lowestVariant.Name
-      //   );
-      //   tempMap.set('Parent_ID', topLevelRecord);
-      //   exportRecordsAndColumns[0].push(tempMap);
-      // }
-      vvIds.clear();
       // update variant value ids and record ids with only those relevant to lowest variants
+      vvIds.clear();
       for (let lowestVariant of lowestVariants) {
         vvIds.add(lowestVariant.Id)
         recordIdSet.add(helper.getValue(lowestVariant, 'Variant__r.Product__c'));
@@ -764,7 +745,6 @@ async function populateRecordDetailsForLowestVariants(lowestVariants) {
   let recordMapList = [];
   let recordMap;
   for (let lowestVariant of lowestVariants) {
-    const topLevelRecord = helper.getValue(lowestVariant, 'Variant__r.Product__c');
     recordMap = new Map();
     recordMap.set('Id', lowestVariant.Id);
     recordMap.set('Record_ID', lowestVariant.Name);
@@ -779,7 +759,7 @@ async function populateRecordDetailsForLowestVariants(lowestVariants) {
         ? helper.getValue(lowestVariant, 'Label__c')
         : lowestVariant.Name
     );
-    recordMap.set('Parent_ID', topLevelRecord);
+    recordMap.set('Parent_ID', helper.getValue(lowestVariant, 'Variant__r.Product__c'));
     recordMapList.push(recordMap);
   }
 

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -106,13 +106,17 @@ async function PimRecordListHelper(
           variantValues,
           namespace
         );
-        console.log('variantValues1: ' + variantValues)
+        for (let varV of variantValues) {
+          console.log('variantValues1: ' + varV)
+        }
         console.log('lowestVariantValueIds: ' + lowestVariantValueIds)
         // filter out all records not selected for export
         variantValues = variantValues.filter(value =>
           lowestVariantValueIds.includes(value.Name)
         );
-        console.log('variantValues2: ' + variantValues)
+        for (let varV of variantValues) {
+          console.log('variantValues2: ' + varV)
+        }
         exportRecordsAndColumns[0] = exportRecordsAndColumns[0].filter(record =>
           lowestVariantValueIds.includes(record.get('Record_ID'))
         );

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -7,7 +7,7 @@ const {
   ATTRIBUTE_FLAG,
   PRODUCT_TYPE,
   callAsposeToExport,
-  getLowestVariantValuesList,
+  extractLowestVariantValues,
   getDigitalAssetMap,
   initAssetDownloadDetailsList,
   parseDigitalAssetAttrVal,
@@ -430,7 +430,7 @@ class PimStructure {
               }
             }
             if (exportType === 'lowestVariants' && !reqBody.isInherited) {
-              const lowestLevelVariantValues = await getLowestVariantValuesList(
+              const lowestLevelVariantValues = await extractLowestVariantValues(
                 valuesList,
                 reqBody.namespace
               );
@@ -718,7 +718,7 @@ class PimStructure {
       }
       exportType = 'currentVariant';
     } else if (exportType === 'lowestVariants') {
-      lowestLevelVariantValues = await getLowestVariantValuesList(
+      lowestLevelVariantValues = await extractLowestVariantValues(
         valuesList,
         reqBody.namespace
       );

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -548,7 +548,14 @@ async function getLowestVariantsFromProducts(productList, reqBody) {
 
   const allVariantsFromProducts = await service.queryExtend(
     helper.namespaceQuery(
-      `select Id, Name, Parent_Value_Path__c, Variant__r.Product__c
+      `select 
+          Id, 
+          Name, 
+          Label__c, 
+          Parent_Value_Path__c, 
+          Variant__r.Product__c, 
+          Variant__r.Product__r.Category__c, 
+          Variant__r.Product__r.Category__r.Name
         from Variant_Value__c
         where Variant__r.Product__c IN (${service.QUERY_LIST})
       `

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -557,10 +557,9 @@ async function getLowestVariantsFromProducts(productList, reqBody) {
   );
 
   const lowestVariantValueIds = await getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
-  const skuVariants = allVariantsFromProducts.filter(value =>
+  return allVariantsFromProducts.filter(value =>
     lowestVariantValueIds.includes(value.Name)
   );
-  console.log('skuVar: ' + skuVariants)
 }
 
 // returns a list of the lowest level variant values' ids (i.e. SKUs) from a list of variant values

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -556,7 +556,10 @@ async function getLowestVariantsFromProducts(productList, reqBody) {
     prepareIdsForSOQL(productList).split(',')
   );
 
-  return getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
+  const lowestVariantValueIds = getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
+  return allVariantsFromProducts.filter(value =>
+    lowestVariantValueIds.includes(value.Name)
+  );
 }
 
 // returns a list of the lowest level variant values' ids (i.e. SKUs) from a list of variant values

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -80,7 +80,7 @@ module.exports = {
   callAsposeToExport,
   cleanString,
   getLowestVariantsFromProducts,
-  getLowestVariantValuesList,
+  extractLowestVariantValues,
   getDigitalAssetMap,
   getNestedField,
   initAssetDownloadDetailsList,
@@ -563,14 +563,14 @@ async function getLowestVariantsFromProducts(productList, reqBody) {
     prepareIdsForSOQL(productList).split(',')
   );
 
-  const lowestVariantValueIds = await getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
+  const lowestVariantValueIds = await extractLowestVariantValues(allVariantsFromProducts, reqBody.namespace);
   return allVariantsFromProducts.filter(value =>
     lowestVariantValueIds.includes(value.Name)
   );
 }
 
 // returns a list of the lowest level variant values' ids (i.e. SKUs) from a list of variant values
-async function getLowestVariantValuesList(valuesList, namespace) {
+async function extractLowestVariantValues(valuesList, namespace) {
   const helper = new PimExportHelper(namespace);
   let numOfParentValues,
     highestNumOfParentValues = 0,

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -556,10 +556,11 @@ async function getLowestVariantsFromProducts(productList, reqBody) {
     prepareIdsForSOQL(productList).split(',')
   );
 
-  const lowestVariantValueIds = getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
-  return allVariantsFromProducts.filter(value =>
+  const lowestVariantValueIds = await getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
+  const skuVariants = allVariantsFromProducts.filter(value =>
     lowestVariantValueIds.includes(value.Name)
   );
+  console.log('skuVar: ' + skuVariants)
 }
 
 // returns a list of the lowest level variant values' ids (i.e. SKUs) from a list of variant values

--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -79,6 +79,7 @@ initAssetDownloadDetailsList = (
 module.exports = {
   callAsposeToExport,
   cleanString,
+  getLowestVariantsFromProducts,
   getLowestVariantValuesList,
   getDigitalAssetMap,
   getNestedField,
@@ -539,6 +540,23 @@ async function callAsposeToExport({
     });
   req.write(JSON.stringify(data));
   req.end();
+}
+
+async function getLowestVariantsFromProducts(productList, reqBody) {
+  const service = new ForceService(reqBody.hostUrl, reqBody.sessionId);
+  const helper = new PimExportHelper(reqBody.namespace);
+
+  const allVariantsFromProducts = await service.queryExtend(
+    helper.namespaceQuery(
+      `select Id, Name, Parent_Value_Path__c, Variant__r.Product__c
+        from Variant_Value__c
+        where Variant__r.Product__c IN (${service.QUERY_LIST})
+      `
+    ),
+    prepareIdsForSOQL(productList).split(',')
+  );
+
+  return getLowestVariantValuesList(allVariantsFromProducts, reqBody.namespace);
 }
 
 // returns a list of the lowest level variant values' ids (i.e. SKUs) from a list of variant values


### PR DESCRIPTION

https://github.com/PropelPLM/pim-data-service/assets/77341283/7a33d452-2667-4b3b-9784-ed638ae18544

- lowest variant export aka SKU export will now export SKUs of the selected records even if some of the SKUs were among the selected records
- this is regardless if the selected record is a product, non SKU variant value, or SKU variant value