### PR TITLE
PIM-972: PIM | Template Export | Make template export support both primary_key and label for attributes

### DIFF
--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -678,7 +678,6 @@ async function addExportColumns(
       const lastHeaderRowIndex = templateHeaders.length - 1;
       const numOfColumnAttributes = columnAttributes.length;
       let missedCount;
-      console.log('defaultCols: ', defaultColumnNames)
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
         isAttributeField = field.includes(ATTRIBUTE_FLAG);

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -695,7 +695,7 @@ async function addExportColumns(
           field = field.slice(11, -1);
           missedCount = 0;
           for (let colAttr of columnAttributes) {
-            if (helper.getValue(colAttr, 'Label__c') === field) {
+            if (field === helper.getValue(colAttr, 'Label__c') || field === helper.getValue(colAttr, 'Primary_Key__c')) {
               exportColumns.push({
                 fieldName: helper.getValue(colAttr, 'Primary_Key__c'),
                 label: templateHeaders[lastHeaderRowIndex][i],

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -678,6 +678,7 @@ async function addExportColumns(
       const lastHeaderRowIndex = templateHeaders.length - 1;
       const numOfColumnAttributes = columnAttributes.length;
       let missedCount;
+      console.log('defaultCols: ', defaultColumnNames)
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
         isAttributeField = field.includes(ATTRIBUTE_FLAG);

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -102,7 +102,6 @@ class PimStructure {
         exportRecordsAndColumns = [exportRecords],
         attrValValue;
 
-      console.log('1 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
       // Map<productId or vvId, Map<Attribute Label Id, DADownloadDetails object>>
       productVariantsDaDetailsMap = new Map();
       appearingLabelIds = prepareIdsForSOQL(appearingLabelIds);
@@ -146,6 +145,7 @@ class PimStructure {
               reqBody
             );
           }
+          console.log('appearingLabel[i]: ', appearingLabels[i])
           exportRecords[0].set(appearingLabels[i].Name, attrValValue);
         }
 
@@ -153,14 +153,12 @@ class PimStructure {
           // add null value to the base product map
           exportRecords[0].set(appearingLabels[i].Name, null);
         }
-        console.log('1.5 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
       }
       /** get product's appearing attribute labels end */
       if (isProduct) {
         let valuesList = [];
 
         if (exportType === 'currentVariant') {
-          console.log('2 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
           if (reqBody.variantValuePath.length > 0) {
             // exporting current variant value (base product not included in export)
             const currentVariantId =

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -101,7 +101,7 @@ class PimStructure {
         exportRecords = [baseRecord],
         exportRecordsAndColumns = [exportRecords],
         attrValValue;
-      console.log('recordList: ', recordList);
+      console.log('baseRecord: ', baseRecord);
 
       // Map<productId or vvId, Map<Attribute Label Id, DADownloadDetails object>>
       productVariantsDaDetailsMap = new Map();

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -1017,6 +1017,7 @@ class PimStructure {
               supportedAttrLabels.has(RECORD_ID_FIELD))
           ) {
             // push columns specified in template
+            console.log('if field: ', field)
             exportColumns = [
               ...exportColumns,
               {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -97,11 +97,11 @@ class PimStructure {
           service,
           isProduct
         ),
-        console.log('recordList: ', recordList);
         baseRecord = productVariantValueMapList[0],
         exportRecords = [baseRecord],
         exportRecordsAndColumns = [exportRecords],
         attrValValue;
+      console.log('recordList: ', recordList);
 
       // Map<productId or vvId, Map<Attribute Label Id, DADownloadDetails object>>
       productVariantsDaDetailsMap = new Map();

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -101,8 +101,8 @@ class PimStructure {
         exportRecords = [baseRecord],
         exportRecordsAndColumns = [exportRecords],
         attrValValue;
-      console.log('baseRecord: ', baseRecord);
 
+      console.log('1 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
       // Map<productId or vvId, Map<Attribute Label Id, DADownloadDetails object>>
       productVariantsDaDetailsMap = new Map();
       appearingLabelIds = prepareIdsForSOQL(appearingLabelIds);
@@ -473,6 +473,7 @@ class PimStructure {
           exportRecordsAndColumns = [exportRecords];
         }
       }
+      console.log('4 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,
@@ -999,7 +1000,7 @@ class PimStructure {
       // clean up data for easier parsing
       const supportedAttrLabels = productVariantValueMapList[0];
       supportedAttrLabels.delete(ID_FIELD);
-      console.log('supportedAttrLabels: ', supportedAttrLabels)
+      console.log('supportedAttrLabels.size: ', supportedAttrLabels.size)
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -97,6 +97,7 @@ class PimStructure {
           service,
           isProduct
         ),
+        console.log('recordList: ', recordList);
         baseRecord = productVariantValueMapList[0],
         exportRecords = [baseRecord],
         exportRecordsAndColumns = [exportRecords],
@@ -996,9 +997,9 @@ class PimStructure {
       const lastHeaderRowIndex = templateHeaders.length - 1;
       let field;
       // clean up data for easier parsing
-      const supportedAttributes = productVariantValueMapList[0];
-      supportedAttributes.delete(ID_FIELD);
-      console.log('supportedAttributes: ', supportedAttributes)
+      const supportedAttrLabels = productVariantValueMapList[0];
+      supportedAttrLabels.delete(ID_FIELD);
+      console.log('supportedAttrLabels: ', supportedAttrLabels)
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
@@ -1007,9 +1008,9 @@ class PimStructure {
           // template specifies that the column's rows should contain a field's value
           field = field.slice(11, -1);
           if (
-            (field !== RECORD_ID_LABEL && supportedAttributes.has(field)) ||
+            (field !== RECORD_ID_LABEL && supportedAttrLabels.has(field)) ||
             (field === RECORD_ID_LABEL &&
-              supportedAttributes.has(RECORD_ID_FIELD))
+              supportedAttrLabels.has(RECORD_ID_FIELD))
           ) {
             // push columns specified in template
             exportColumns = [

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -1026,6 +1026,8 @@ class PimStructure {
               }
             ];
           } else if (field !== RECORD_ID_LABEL && supportedAttrPriKeyLabelMap.has(field)) {
+            console.log('else if reached')
+            console.log('supportedAttrPriKeyLabelMap.get(field): ', supportedAttrPriKeyLabelMap.get(field))
             // convert primary key fields to labels and push columns specified in template
             exportColumns = [
               ...exportColumns,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -998,6 +998,7 @@ class PimStructure {
       // clean up data for easier parsing
       const supportedAttributes = productVariantValueMapList[0];
       supportedAttributes.delete(ID_FIELD);
+      console.log('supportedAttributes: ', supportedAttributes)
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -1004,6 +1004,7 @@ class PimStructure {
       const supportedAttrLabels = productVariantValueMapList[0];
       supportedAttrLabels.delete(ID_FIELD);
       console.log('supportedAttrLabels.size: ', supportedAttrLabels.size)
+      console.log('supportedAttrPriKeyLabelMap: ', supportedAttrPriKeyLabelMap)
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -153,6 +153,7 @@ class PimStructure {
           // add null value to the base product map
           exportRecords[0].set(appearingLabels[i].Name, null);
         }
+        console.log('1.5 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
       }
       /** get product's appearing attribute labels end */
       if (isProduct) {
@@ -279,7 +280,6 @@ class PimStructure {
             currentVariantName = currentVariant.get('Record_ID');
             // overwrite base product with current variant
             exportRecords = [currentVariant];
-            console.log('3 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
           }
         } else if (
           exportType === 'allVariants' ||
@@ -475,7 +475,6 @@ class PimStructure {
           exportRecordsAndColumns = [exportRecords];
         }
       }
-      console.log('4 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
       exportRecordsColsAndAssets = {
         daDownloadDetailsList: await this.getFinalizedDaList(
           reqBody.isInherited,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -1003,8 +1003,6 @@ class PimStructure {
       // clean up data for easier parsing
       const supportedAttrLabels = productVariantValueMapList[0];
       supportedAttrLabels.delete(ID_FIELD);
-      console.log('supportedAttrLabels.size: ', supportedAttrLabels.size)
-      console.log('supportedAttrPriKeyLabelMap: ', supportedAttrPriKeyLabelMap)
 
       for (let i = 0; i < templateFields.length; i++) {
         field = templateFields[i];
@@ -1018,7 +1016,6 @@ class PimStructure {
               supportedAttrLabels.has(RECORD_ID_FIELD))
           ) {
             // push columns specified in template
-            console.log('if field: ', field)
             exportColumns = [
               ...exportColumns,
               {
@@ -1028,8 +1025,6 @@ class PimStructure {
               }
             ];
           } else if (field !== RECORD_ID_LABEL && supportedAttrPriKeyLabelMap.has(field)) {
-            console.log('else if reached')
-            console.log('supportedAttrPriKeyLabelMap.get(field): ', supportedAttrPriKeyLabelMap.get(field))
             // convert primary key fields to labels and push columns specified in template
             exportColumns = [
               ...exportColumns,

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -159,6 +159,7 @@ class PimStructure {
         let valuesList = [];
 
         if (exportType === 'currentVariant') {
+          console.log('2 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
           if (reqBody.variantValuePath.length > 0) {
             // exporting current variant value (base product not included in export)
             const currentVariantId =
@@ -278,6 +279,7 @@ class PimStructure {
             currentVariantName = currentVariant.get('Record_ID');
             // overwrite base product with current variant
             exportRecords = [currentVariant];
+            console.log('3 productVariantValueMapList[0].size: ', productVariantValueMapList[0].size)
           }
         } else if (
           exportType === 'allVariants' ||

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -148,7 +148,7 @@ class PimStructure {
           }
           exportRecords[0].set(appearingLabels[i].Name, attrValValue);
           // populate a Map of <Attribute_Label__r.Primary_Key__c, Attribute_Label__r.Name>
-          supportedAttrPriKeyLabelMap.set(helper.getValue(appearingValues[i], 'Primary_Key__c'), appearingLabels[i].Name);
+          supportedAttrPriKeyLabelMap.set(helper.getValue(appearingLabels[i], 'Primary_Key__c'), appearingLabels[i].Name);
         }
 
         if (!exportRecords[0].has(appearingLabels[i].Name)) {

--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -1065,7 +1065,7 @@ class PimStructure {
   async parseAppearringAttrLabelsAndValues(appearingLabelIds, service) {
     // add appearing attribute labels and their values to base product
     const appearingLabels = await service.simpleQuery(
-      helper.namespaceQuery(`select Id, Name
+      helper.namespaceQuery(`select Id, Name, Primary_Key__c
       from Attribute_Label__c
       where Id IN (${appearingLabelIds})`)
     );


### PR DESCRIPTION
- add `Primary_Key__c` field to the query for `Attribute_Label__c`
- if template field matches either `Primary_Key__c` or `Label__c` field of `Attribute_Label__c`, create an export column corresponding to that `Attribute_Label__c`

https://github.com/PropelPLM/pim-data-service/assets/77341283/d6c61725-bdb0-4176-a58c-dd0abd4bf9cd

