### PR TITLE
PIM-1381 | slice it up bruh

### DIFF
--- a/lib/ImportCategory.js
+++ b/lib/ImportCategory.js
@@ -74,9 +74,10 @@ class ImportCategory extends ImportClass {
     }
 
     if (insertCategories.length > 0) {
-      let results = await this.connection.insert(
+      let results = await this.connection.insertSlice(
         this.helper.namespace('Category__c'),
-        insertCategories
+        insertCategories,
+        100
       )
 
       this.log.addToLogs(results, this.helper.namespace('Category__c'))


### PR DESCRIPTION
Looks like this method in PIM, `beforeInsertMaxNodeDepth` causes the SOQL limits to get out of control really fast. In about 166 category inserts. So this change slices up the batches into sets of 100 so that method stays low. 

We should think about removing it anyway not sure why we care about Categories having more than 12 kids.