### PR TITLE
PIM-1456: PIM | Export | PLP export is duplicating first record

### DIFF
--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -215,7 +215,6 @@ async function getRecordByCategory(
   } else {
     pm = await buildStructureWithSecondaryCategoryIds(listCategoryIds);
   }
-  console.log('pm: ', pm)
   let tempRecords = await PimRecordService(pm, helper, service);
   return tempRecords;
 }

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -93,6 +93,7 @@ async function PimRecordListHelper(
       // get SKUs (lowest variants) of parent products of selected records
       const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
       exportRecordsAndColumns[0] = await populateRecordDetailsForLowestVariants(lowestVariants);
+      console.log('1: ', exportRecordsAndColumns[0]);
       // update variant value ids and record ids with only those relevant to lowest variants
       vvIds.clear();
       for (let lowestVariant of lowestVariants) {
@@ -147,6 +148,7 @@ async function PimRecordListHelper(
     exportRecordsAndColumns[0].sort((a, b) =>
       a.get('Record_ID') > b.get('Record_ID') ? 1 : -1
     );
+    console.log('2: ', exportRecordsAndColumns[0]);
 
     /** PIM repo ProductService.getProductDetail end */
     // for each key of attribute results (Product__c Id or Variant_Value__c Id)

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -61,6 +61,7 @@ async function PimRecordListHelper(
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
+  console.log('1: ', exportRecordsAndColumns[0])
 
   /** PIM repo ProductService.productStructureByCategory end */
 
@@ -93,7 +94,6 @@ async function PimRecordListHelper(
       // get SKUs (lowest variants) of parent products of selected records
       const lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
       exportRecordsAndColumns[0] = await populateRecordDetailsForLowestVariants(lowestVariants);
-      console.log('1: ', exportRecordsAndColumns[0]);
       // update variant value ids and record ids with only those relevant to lowest variants
       vvIds.clear();
       for (let lowestVariant of lowestVariants) {
@@ -148,7 +148,6 @@ async function PimRecordListHelper(
     exportRecordsAndColumns[0].sort((a, b) =>
       a.get('Record_ID') > b.get('Record_ID') ? 1 : -1
     );
-    console.log('2: ', exportRecordsAndColumns[0]);
 
     /** PIM repo ProductService.getProductDetail end */
     // for each key of attribute results (Product__c Id or Variant_Value__c Id)

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -57,12 +57,10 @@ async function PimRecordListHelper(
     isSKUExport = exportType === 'lowestVariants';
 
   // filter the records if rows were selected or filters applied in product list page
-  console.log('exportRecords: ', exportRecords)
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
-  console.log('filteredRecords: ', exportRecordsAndColumns[0])
 
   /** PIM repo ProductService.productStructureByCategory end */
 
@@ -217,6 +215,7 @@ async function getRecordByCategory(
   } else {
     pm = await buildStructureWithSecondaryCategoryIds(listCategoryIds);
   }
+  console.log('pm: ', pm)
   let tempRecords = await PimRecordService(pm, helper, service);
   return tempRecords;
 }

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -57,11 +57,12 @@ async function PimRecordListHelper(
     isSKUExport = exportType === 'lowestVariants';
 
   // filter the records if rows were selected or filters applied in product list page
+  console.log('exportRecords: ', exportRecords)
   let filteredRecords = exportRecords.filter(record => {
     return recordIds?.includes(record.get('Id')) || variantValueIds?.includes(record.get('Id'));
   });
   let exportRecordsAndColumns = [filteredRecords]; // [[filtered]] zz
-  console.log('1: ', exportRecordsAndColumns[0])
+  console.log('filteredRecords: ', exportRecordsAndColumns[0])
 
   /** PIM repo ProductService.productStructureByCategory end */
 

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -22,14 +22,11 @@ async function PimRecordService(
 // PIM repo ProductService.getResultForProductStructure(recordList)
 // returns List of Maps
 async function getResultForProductStructure(recordList, isProduct) {
-  let productVariantValueMapList = [];
+  let productVariantValueMapList = isProduct ? [] : [populateRecordDetailsMap(helper, recordList[0])];
 
-  if (!isProduct) {
-    // populate digital asset record details
-    productVariantValueMapList = [populateRecordDetailsMap(helper, recordList[0])];
-    return productVariantValueMapList;
-  }
-
+  // return digital asset record details
+  if (!isProduct) return productVariantValueMapList;
+  
   let variantStructure = await getVariantStructure(recordList),
     productVariants,
     variantValues;

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -29,7 +29,6 @@ async function getResultForProductStructure(recordList, isProduct) {
     productVariantValueMapList = [populateRecordDetailsMap(helper, recordList[0])];
     return productVariantValueMapList;
   }
-  console.log('1. productVariantValueMapList: ', productVariantValueMapList)
 
   let variantStructure = await getVariantStructure(recordList),
     productVariants,
@@ -51,7 +50,6 @@ async function getResultForProductStructure(recordList, isProduct) {
       });
     });
   });
-  console.log('2. productVariantValueMapList: ', productVariantValueMapList)
   return productVariantValueMapList;
 }
 

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -22,6 +22,7 @@ async function PimRecordService(
 // PIM repo ProductService.getResultForProductStructure(recordList)
 // returns List of Maps
 async function getResultForProductStructure(recordList, isProduct) {
+  console.log('recordList: ', recordList)
   let productVariantValueMapList = [
     populateRecordDetailsMap(helper, recordList[0])
   ];

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -22,12 +22,15 @@ async function PimRecordService(
 // PIM repo ProductService.getResultForProductStructure(recordList)
 // returns List of Maps
 async function getResultForProductStructure(recordList, isProduct) {
-  let productVariantValueMapList = [
-    populateRecordDetailsMap(helper, recordList[0])
-  ];
+  let productVariantValueMapList = [];
+
+  if (!isProduct) {
+    // populate digital asset record details
+    productVariantValueMapList = [populateRecordDetailsMap(helper, recordList[0])];
+    return productVariantValueMapList;
+  }
   console.log('1. productVariantValueMapList: ', productVariantValueMapList)
 
-  if (!isProduct) return productVariantValueMapList;
   let variantStructure = await getVariantStructure(recordList),
     productVariants,
     variantValues;

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -22,10 +22,10 @@ async function PimRecordService(
 // PIM repo ProductService.getResultForProductStructure(recordList)
 // returns List of Maps
 async function getResultForProductStructure(recordList, isProduct) {
-  console.log('recordList: ', recordList)
   let productVariantValueMapList = [
     populateRecordDetailsMap(helper, recordList[0])
   ];
+  console.log('1. productVariantValueMapList: ', productVariantValueMapList)
 
   if (!isProduct) return productVariantValueMapList;
   let variantStructure = await getVariantStructure(recordList),
@@ -48,7 +48,7 @@ async function getResultForProductStructure(recordList, isProduct) {
       });
     });
   });
-  console.log('productVariantValueMapList: ', productVariantValueMapList)
+  console.log('2. productVariantValueMapList: ', productVariantValueMapList)
   return productVariantValueMapList;
 }
 

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -48,6 +48,7 @@ async function getResultForProductStructure(recordList, isProduct) {
       });
     });
   });
+  console.log('productVariantValueMapList: ', productVariantValueMapList)
   return productVariantValueMapList;
 }
 


### PR DESCRIPTION
<img width="326" alt="image" src="https://github.com/PropelPLM/pim-data-service/assets/77341283/897de6a2-af11-4ee1-8017-edc7131bce64">

Added ternary operator to only append first record when it's digital asset export (preventing duplicate 1st record when product and variants are populated afterwards)