### PR TITLE
PIM-1473: PIM | Export | PLP Export Does Not Show Inherited Values

### DIFF
--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -432,7 +432,7 @@ async function getAttributesForRecordMap(
 
       let attrValValue = helper.getValue(
         attribute,
-        (attribute[helper.namespace('Value_Long__c')]) ? 'Value_Long__c' : 'Value__c'
+        helper.getValue(attribute, 'Value_Long__c') ? 'Value_Long__c' : 'Value__c'
       );
       // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
       if (
@@ -484,7 +484,7 @@ async function getAttributesForRecordMap(
           }
           let attrValValue = helper.getValue(
             attribute,
-            ([helper.namespace('Value_Long__c')]) ? 'Value_Long__c' : 'Value__c'
+            helper.getValue(attribute, 'Value_Long__c') ? 'Value_Long__c' : 'Value__c'
           );
           // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
           if (
@@ -522,7 +522,7 @@ async function getAttributesForRecordMap(
 
         let attrValValue = helper.getValue(
           attribute,
-          ([helper.namespace('Value_Long__c')]) ? 'Value_Long__c' : 'Value__c'
+          helper.getValue(attribute, 'Value_Long__c') ? 'Value_Long__c' : 'Value__c'
         );
         // replace digital asset id with CDN url if Attribute_Label__c is of Type__c 'DigitalAsset'
         if (


### PR DESCRIPTION
<img width="1016" alt="image" src="https://github.com/PropelPLM/pim-data-service/assets/77341283/5434e43c-9aea-4c4e-b67c-ec4201cd9c14">

- Fixed a typo (lines 487 and 525) that just check if `([helper.namespace('Value_Long__c')])` evaluates to true. 
- Line 435 is technically correct but changing it for consistency and to be more readable