### PR TITLE
PIM-1524 | forgot one place for namespace

### DIFF
--- a/legacy/PimStructure.js
+++ b/legacy/PimStructure.js
@@ -129,7 +129,7 @@ class PimStructure {
           
           // PIM-1359 reopen: having to do this Value_Long__c logic all through out the code because we don't
           // have a central place where PIM data model to consumable object conversion. 
-          const theValue = (appearingValues[j]['Value_Long__c']) ? 'Value_Long__c' : 'Value__c';
+          const theValue = (helper.getValue(appearingValues[j], 'Value_Long__c')) ? 'Value_Long__c' : 'Value__c';
           attrValValue = helper.getValue(appearingValues[j], theValue);
           
           if (


### PR DESCRIPTION
I compared the two PIM Logs from QA to UAT and saw the tell-tell sign of namespace. The genius that implemented Logger in PIM will always be valued. Thank goodness he was smart enough to create a tool that made it easy to fine all of his own mistakes. Looks like this will be my last PR for the Propel eng team. Seems fitting I am fixing a bug I caused, but I am proud of what the PIM team created, and I am proud I was apart of it. I feel like there is so much more todo and with a sad heart I will not be able to finish what I started.