### PR TITLE
PIM-1937 | PIM | API | New Export API for entire database

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const ImportCommerceProduct = require('./lib/ImportCommerceProduct');
 const ImportProduct = require('./lib/ImportProduct');
 const ExportPim = require('./lib/ExportProduct');
 
-const LegacyExportPim = require('./legacy/ExportPIM');
+const { LegacyExportPim, createExportFilename, createDaZipFilename } = require('./legacy/ExportPIM');
 
 const ERROR_OBJ = { message: '', success: false };
 const SUCCESS_OBJ = { message: 'Request received', success: true };
@@ -189,11 +189,23 @@ app.post('/export/pim/product', (req, res) => {
 /**
  * route for legacy exporter
  */
-app.post('/export/legacy/pim/product', async (req, res) => {
+app.post('/export/legacy/pim/product', (req, res) => {
   try {
     printBody(req);
-    const result = await LegacyExportPim(req);
-    res.status(200).send(JSON.parse(JSON.stringify(result)));
+
+    const filename = createExportFilename(req.recordType, req.exportFormat);
+    let daZipFilename;
+    if (req.includeRecordAsset) {
+      daZipFilename = createDaZipFilename();
+    }
+
+    LegacyExportPim(req, filename, daZipFilename);
+    
+    const retBody = {
+      exportFilename: filename,
+      daZipFilename
+    }
+    res.status(200).send(JSON.parse(JSON.stringify(retBody)));
   } catch (err) {
     res.status(400).send('');
   }

--- a/index.js
+++ b/index.js
@@ -193,10 +193,12 @@ app.post('/export/legacy/pim/product', (req, res) => {
   try {
     printBody(req);
 
-    const filename = createExportFilename(req.body.recordType, req.body.exportFormat);
+    const { recordType, exportFormat, includeRecordAsset } = req.body;
+
+    const filename = createExportFilename(recordType, exportFormat);
     console.log('filename: ', filename);
     let daZipFilename;
-    if (req.body.includeRecordAsset) {
+    if (includeRecordAsset) {
       daZipFilename = createDaZipFilename();
     }
 
@@ -206,7 +208,7 @@ app.post('/export/legacy/pim/product', (req, res) => {
     
     const retBody = {
       exportFilename: filename,
-      daZipFilename
+      daZipFilename: daZipFilename ? daZipFilename : null
     }
     console.log('retBody: ', JSON.parse(JSON.stringify(retBody)));
     res.status(200).send(JSON.parse(JSON.stringify(retBody)));

--- a/index.js
+++ b/index.js
@@ -189,10 +189,10 @@ app.post('/export/pim/product', (req, res) => {
 /**
  * route for legacy exporter
  */
-app.post('/export/legacy/pim/product', (req, res) => {
+app.post('/export/legacy/pim/product', async (req, res) => {
   try {
     printBody(req);
-    const result = LegacyExportPim(req);
+    const result = await LegacyExportPim(req);
     console.log('result: ', JSON.parse(JSON.stringify(result)));
     res.status(200).send(JSON.parse(JSON.stringify(result)));
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -192,8 +192,8 @@ app.post('/export/pim/product', (req, res) => {
 app.post('/export/legacy/pim/product', (req, res) => {
   try {
     printBody(req);
-    LegacyExportPim(req);
-    res.status(200).send('');
+    const result = LegacyExportPim(req);
+    res.status(200).send(JSON.parse(JSON.stringify(result)));
   } catch (err) {
     res.status(400).send('');
   }

--- a/index.js
+++ b/index.js
@@ -194,10 +194,13 @@ app.post('/export/legacy/pim/product', (req, res) => {
     printBody(req);
 
     const filename = createExportFilename(req.recordType, req.exportFormat);
+    console.log('filename: ', filename);
     let daZipFilename;
     if (req.includeRecordAsset) {
       daZipFilename = createDaZipFilename();
     }
+
+    console.log('daZipFilename: ', daZipFilename);
 
     LegacyExportPim(req, filename, daZipFilename);
     
@@ -205,6 +208,7 @@ app.post('/export/legacy/pim/product', (req, res) => {
       exportFilename: filename,
       daZipFilename
     }
+    console.log('retBody: ', JSON.parse(JSON.stringify(retBody)));
     res.status(200).send(JSON.parse(JSON.stringify(retBody)));
   } catch (err) {
     res.status(400).send('');

--- a/index.js
+++ b/index.js
@@ -193,6 +193,7 @@ app.post('/export/legacy/pim/product', (req, res) => {
   try {
     printBody(req);
     const result = LegacyExportPim(req);
+    console.log('result: ', JSON.parse(JSON.stringify(result)));
     res.status(200).send(JSON.parse(JSON.stringify(result)));
   } catch (err) {
     res.status(400).send('');

--- a/index.js
+++ b/index.js
@@ -193,7 +193,6 @@ app.post('/export/legacy/pim/product', async (req, res) => {
   try {
     printBody(req);
     const result = await LegacyExportPim(req);
-    console.log('result: ', JSON.parse(JSON.stringify(result)));
     res.status(200).send(JSON.parse(JSON.stringify(result)));
   } catch (err) {
     res.status(400).send('');

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const ImportCommerceProduct = require('./lib/ImportCommerceProduct');
 const ImportProduct = require('./lib/ImportProduct');
 const ExportPim = require('./lib/ExportProduct');
 
-const { LegacyExportPim, createExportFilename, createDaZipFilename } = require('./legacy/ExportPIM');
+const { LegacyExportPIM, createExportFilename, createDaZipFilename } = require('./legacy/ExportPIM');
 
 const ERROR_OBJ = { message: '', success: false };
 const SUCCESS_OBJ = { message: 'Request received', success: true };
@@ -196,21 +196,17 @@ app.post('/export/legacy/pim/product', (req, res) => {
     const { recordType, exportFormat, includeRecordAsset } = req.body;
 
     const filename = createExportFilename(recordType, exportFormat);
-    console.log('filename: ', filename);
     let daZipFilename;
     if (includeRecordAsset) {
       daZipFilename = createDaZipFilename();
     }
 
-    console.log('daZipFilename: ', daZipFilename);
-
-    LegacyExportPim(req, filename, daZipFilename);
+    LegacyExportPIM(req, filename, daZipFilename);
     
     const retBody = {
       exportFilename: filename,
       daZipFilename: daZipFilename ? daZipFilename : null
     }
-    console.log('retBody: ', JSON.parse(JSON.stringify(retBody)));
     res.status(200).send(JSON.parse(JSON.stringify(retBody)));
   } catch (err) {
     res.status(400).send('');

--- a/index.js
+++ b/index.js
@@ -193,10 +193,10 @@ app.post('/export/legacy/pim/product', (req, res) => {
   try {
     printBody(req);
 
-    const filename = createExportFilename(req.recordType, req.exportFormat);
+    const filename = createExportFilename(req.body.recordType, req.body.exportFormat);
     console.log('filename: ', filename);
     let daZipFilename;
-    if (req.includeRecordAsset) {
+    if (req.body.includeRecordAsset) {
       daZipFilename = createDaZipFilename();
     }
 

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -20,6 +20,7 @@ const {
 const { getSessionId } = require('../lib/utility')
 
 async function LegacyExportPIM(req, filename, daZipFilename) {
+  console.log('is this even runnning');
   const reqBody = req.body;
   const isListPageExport = reqBody.options.isListPageExport;
   // Create csv string result with records and columns in request body
@@ -70,6 +71,8 @@ async function LegacyExportPIM(req, filename, daZipFilename) {
   }
 
   const exportFormat = reqBody.exportFormat;
+  console.log('exportFormat: ', exportFormat);
+  console.log('reqBody: ', JSON.parse(JSON.stringify(reqBody)));
   if (exportFormat == 'csv') {
     // CSV -> CSV export (both template and non-template)
     const nameOnDisk = crypto.randomBytes(20).toString('hex') + filename;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -48,11 +48,14 @@ async function LegacyExportPIM(req) {
   const baseFileName = createBaseFileName();
   const filename = `${reqBody.recordType}-Export_${baseFileName}.csv`;
 
-  sendDADownloadRequests(
-    baseFileName,
-    daDownloadDetailsList,
-    reqBody
-  );
+  let daZipFilename;
+  if (reqBody.includeRecordAsset) {
+  let daZipFilename = sendDADownloadRequests(
+      baseFileName,
+      daDownloadDetailsList,
+      reqBody
+    );
+  }
 
   if (!reqBody.includeAttributes) return;
   if (recordsAndCols?.length !== 2) {
@@ -93,7 +96,11 @@ async function LegacyExportPIM(req) {
       reqBody.templateId
     );
   }
-  return csvString;
+  return {
+    csvString,
+    exportFilename: filename,
+    daZipFilename
+  };
 }
 
 function convertArrayOfObjectsToCSV(
@@ -220,6 +227,8 @@ async function sendDADownloadRequests(
     archive.finalize();
     console.log('File zipped successfully.');
   })
+
+  return zipFileName;
 }
 
 // GET digital asset, convert the fileContent buffer into a stream to be appended to the zip archiver

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -50,7 +50,7 @@ async function LegacyExportPIM(req) {
 
   let daZipFilename;
   if (reqBody.includeRecordAsset) {
-  let daZipFilename = sendDADownloadRequests(
+    daZipFilename = sendDADownloadRequests(
       baseFileName,
       daDownloadDetailsList,
       reqBody
@@ -96,6 +96,7 @@ async function LegacyExportPIM(req) {
       reqBody.templateId
     );
   }
+
   return {
     csvString,
     exportFilename: filename,

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -20,7 +20,6 @@ const {
 const { getSessionId } = require('../lib/utility')
 
 async function LegacyExportPIM(req, filename, daZipFilename) {
-  console.log('is this even runnning');
   const reqBody = req.body;
   const isListPageExport = reqBody.options.isListPageExport;
   // Create csv string result with records and columns in request body
@@ -71,8 +70,6 @@ async function LegacyExportPIM(req, filename, daZipFilename) {
   }
 
   const exportFormat = reqBody.exportFormat;
-  console.log('exportFormat: ', exportFormat);
-  console.log('reqBody: ', JSON.parse(JSON.stringify(reqBody)));
   if (exportFormat == 'csv') {
     // CSV -> CSV export (both template and non-template)
     const nameOnDisk = crypto.randomBytes(20).toString('hex') + filename;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -45,8 +45,9 @@ async function LegacyExportPIM(req) {
     console.log('error: ', err);
   }
 
+  const exportFormat = reqBody.exportFormat;
   const baseFileName = createBaseFileName();
-  const filename = `${reqBody.recordType}-Export_${baseFileName}.csv`;
+  const filename = `${reqBody.recordType}-Export_${baseFileName}.${exportFormat}`;
 
   let daZipFilename;
   if (reqBody.includeRecordAsset) {
@@ -73,7 +74,7 @@ async function LegacyExportPIM(req) {
     return;
   }
 
-  if (reqBody.exportFormat == 'csv') {
+  if (exportFormat == 'csv') {
     // CSV -> CSV export (both template and non-template)
     const nameOnDisk = crypto.randomBytes(20).toString('hex') + filename;
     const file = fs.createWriteStream(nameOnDisk);
@@ -86,7 +87,7 @@ async function LegacyExportPIM(req) {
         console.log('error: ', err);
       }
     });
-  } else if (reqBody.exportFormat == 'xlsx') {
+  } else if (exportFormat == 'xlsx') {
     // CSV -> XLSX export OR XLSX non template export
     sendCsvToAsposeCells(
       csvString,
@@ -94,8 +95,11 @@ async function LegacyExportPIM(req) {
       reqBody.useAsposeStaging,
       reqBody.hostUrl,
       reqBody.templateId
-    );
-  }
+    ) 
+  } else {
+      logErrorResponse(`${exportFormat} is not supported. Only \'csv\' and \'xlsx\' are supported.`, '[ExportPIM]');
+      return;
+  };
 
   return {
     csvString,

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -69,6 +69,7 @@ async function LegacyExportPIM(req, filename, daZipFilename) {
     return;
   }
 
+  const exportFormat = reqBody.exportFormat;
   if (exportFormat == 'csv') {
     // CSV -> CSV export (both template and non-template)
     const nameOnDisk = crypto.randomBytes(20).toString('hex') + filename;

--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -218,7 +218,7 @@ async function sendDADownloadRequests(
   }
   Promise.all(promises).then(() => {
     archive.on('finish', () => {
-      postToChatter(zipFileName, zipFileNameOnDisk, '', reqBody);
+      postToChatter(daZipFilename, zipFileNameOnDisk, '', reqBody);
     });
     archive.finalize();
     console.log('File zipped successfully.');


### PR DESCRIPTION
Related PR in PIM: https://github.com/PropelPLM/PIM/pull/1712

- Shift creating of filenames into parent method so that we can return it. Else if it were to be done in the `LegacyExportPIM()` method, it would not run finish in time for the filenames to be returned.
- Export now returns:
```
{
  exportFilename: filename,
  daZipFilename
}
```
- Do check for `includeRecordAsset`. If true, the DA zip file will be sent to Chatter, else it won't.
- Add `exportFormat` into filename.

**NOTE:** I've tested exporting via UI and it still works as expected. No change in behavior. DA zip files are still posted to Chatter.