### PR TITLE
PIM-1967 | PIM | Export All | Button to export all data with Filter | 1B

### DIFF
--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -94,6 +94,9 @@ async function PimRecordListHelper(
       // get SKUs (lowest variants) of parent products of selected records
       let lowestVariants = await getLowestVariantsFromProducts(productsToQueryForSKU, reqBody);
       if (exportOption === 'export-filtered') {
+        // For export-filtered, we want to apply What You See Is What You Get (WYSIWYG).
+        // The variantValueIds here are passed in from the BE and it may potentially contain lowest variants.
+        // Hence, to only show WYSIWYG, we have to filter out these variantValueIds in lowestVariants.
         lowestVariants = lowestVariants.filter(lowestVariant => {
           return variantValueIds.includes(lowestVariant.Id);
         });


### PR DESCRIPTION
Add logic for determining which lowest variant IDs we export when doing 'export-filtered'. 
This is so that we support the What You See Is What You Get (WYSIWYG) export.