### PR TITLE
PIM-1987: PIM | Export | Header too long: getRecordByCategory

### DIFF
--- a/legacy/ExportPIM.js
+++ b/legacy/ExportPIM.js
@@ -29,7 +29,7 @@ async function LegacyExportPIM(req, filename, daZipFilename) {
 
   // highjacking the flow here are inserting the session id from the JWT flow
   const response = await getSessionId({
-    isTest: reqBody.isTest,
+    isTest: reqBody.isTest || reqBody.instanceUrl?.includes('.sandbox.my'),
     user: reqBody.user
   });
   reqBody.sessionId = response.access_token;

--- a/legacy/PimRecordListHelper.js
+++ b/legacy/PimRecordListHelper.js
@@ -50,6 +50,7 @@ async function PimRecordListHelper(
   };
 
   // PIM repo ProductPQLHelper.getRecordByCategory()
+  // TODO: Should not query all product. only the targeted recordIds
   const exportRecords = await getRecordByCategory(
       pqlBuilder,
       isPrimaryCategory,
@@ -292,7 +293,7 @@ async function buildStructureWithCategoryIds(
     throw 'No Category Ids';
   }
   // return list of records
-  return await service.simpleQuery(
+  return await service.queryExtend(
     helper.namespaceQuery(
       `select Id, Name, Category__c, Category__r.Name, ${
         isProduct ? 'Completeness_Score__c,' : 'CreatedDate, Asset_Status__c, External_File_Id__c, Mime_Type__c, Size__c, View_Link__c,'
@@ -336,8 +337,8 @@ async function buildStructureWithCategoryIds(
       from Product__c`
           : ` from Digital_Asset__c`
       }
-      where Category__c IN (${listCategoryIds})`
-    )
+      where Category__c IN (${service.QUERY_LIST})`.replace(/\n/g, ' ')
+    ), listCategoryIds.split(',')
   );
 }
 
@@ -361,7 +362,7 @@ async function buildStructureWithSecondaryCategoryIds(listCategoryIds) {
     });
     productIds = prepareIdsForSOQL(productIds);
     // return productsList
-    return await service.simpleQuery(
+    return await service.queryExtend(
       helper.namespaceQuery(
         `select Id, Name, Category__c, Category__r.Name,
       (
@@ -399,8 +400,8 @@ async function buildStructureWithSecondaryCategoryIds(listCategoryIds) {
         from Variants__r
       )
       from Product__c
-      where Id IN (${productIds})`
-      )
+      where Id IN (${service.QUERY_LIST})`.replace(/\n/g, ' ')
+      ), productIds.split(',')
     );
   }
 }

--- a/legacy/PimRecordService.js
+++ b/legacy/PimRecordService.js
@@ -57,7 +57,7 @@ async function getVariantStructure(productsList) {
   const variantStructure = new Map();
 
   if (productsIds.length == 0) return variantStructure;
-  const variantsList = await service.simpleQuery(
+  const variantsList = await service.queryExtend(
     helper.namespaceQuery(
       `select Id, Name, Product__c,
       (
@@ -71,9 +71,8 @@ async function getVariantStructure(productsList) {
         order by Name
       )
       from Variant__c
-      where Product__c IN (${productsIds})
-      order by Order__c`
-    )
+      where Product__c IN (${service.QUERY_LIST})`.replace(/\n/g, ' ')
+    ), productsIds.split(',')
   );
 
   let variantParentProductId;

--- a/local/testLegacyExportProduct.js
+++ b/local/testLegacyExportProduct.js
@@ -1,11 +1,12 @@
-const LegacyExportProduct = require('../legacy/ExportPIM')
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+import {LegacyExportPIM} from '../legacy/ExportPIM.js'
 
 const treq = {
   body: {
-    clientId: '3MVG9vDPWAliPr7qI2eOWh9MTRBEzmvX6wKco2wZIs46S42fsNODO7MyZIMxJgQB0qycwRNnwAFCebFZ7Pspf',
     isTest: true,
     user: 'test-lwa0dgwoissf@example.com',
-    sessionId: '',
     namespace: 'PIM__',
     instanceUrl: 'https://velocity-momentum-7312-dev-ed.scratch.my.salesforce.com',
     hostUrl: 'velocity-momentum-7312-dev-ed.scratch.my.salesforce.com',
@@ -36,4 +37,4 @@ const treq = {
   }
 }
 
-LegacyExportProduct(treq)
+LegacyExportPIM(treq, 'testFilename', 'daTestFilename')


### PR DESCRIPTION
Replace `simpleQuery ` with `queryExtend `

Root problem: We query the entire product tree under the category, even though we already know which Products to export. We will fix this when we revamp the app