### PR TITLE
PIM-1981 | PIM | Create flag to Limit 10 product 30 variance

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,7 @@ app.post('/import/pim/product', (req, res) => {
     new ImportProduct(req, res);
     res.status(200).send(SUCCESS_OBJ);
   } catch (error) {
+    console.log('error: ', JSON.parse(JSON.stringify(error)));
     ERROR_OBJ.message = error;
     res.status(400).send(ERROR_OBJ);
     console.error(ERROR_OBJ)

--- a/index.js
+++ b/index.js
@@ -163,7 +163,6 @@ app.post('/import/pim/product', (req, res) => {
     new ImportProduct(req, res);
     res.status(200).send(SUCCESS_OBJ);
   } catch (error) {
-    console.log('error: ', JSON.parse(JSON.stringify(error)));
     ERROR_OBJ.message = error;
     res.status(400).send(ERROR_OBJ);
     console.error(ERROR_OBJ)

--- a/lib/ImportProduct.js
+++ b/lib/ImportProduct.js
@@ -6,6 +6,8 @@ const PimProduct = require('../service/PimProduct')
 const PimVariantValue = require('../service/PimVariantValue')
 const History = require('../service/History')
 
+const { parseResultsForErrors } = require('./utility');
+
 class ImportProduct extends ImportClass {
   /**
    * @param {HttpRequest} req
@@ -199,7 +201,7 @@ class ImportProduct extends ImportClass {
 
     if (insertProducts.length > 0) {
       let results = await this.connection.insertSlice(this.helper.namespace('Product__c'), insertProducts, this.insertSliceSize)
-      console.log('results: ', JSON.parse(JSON.stringify(results)));
+      results = parseResultsForErrors(results);
       this.log.addToLogs(results, 'Product__c')
     }
   }
@@ -327,7 +329,7 @@ class ImportProduct extends ImportClass {
 
     if (insertVariantValues.length > 0) {
       let results = await this.connection.insertSlice(this.helper.namespace('Variant_Value__c'), insertVariantValues, this.insertSliceSize)
-      console.log('variant value results: ', JSON.parse(JSON.stringify(results)));
+      results = parseResultsForErrors(results);
       this.log.addToLogs(results, 'Variant_Value__c')
     }
   }

--- a/lib/ImportProduct.js
+++ b/lib/ImportProduct.js
@@ -199,6 +199,7 @@ class ImportProduct extends ImportClass {
 
     if (insertProducts.length > 0) {
       let results = await this.connection.insertSlice(this.helper.namespace('Product__c'), insertProducts, this.insertSliceSize)
+      console.log('results: ', JSON.parse(JSON.stringify(results)));
       this.log.addToLogs(results, 'Product__c')
     }
   }
@@ -326,6 +327,7 @@ class ImportProduct extends ImportClass {
 
     if (insertVariantValues.length > 0) {
       let results = await this.connection.insertSlice(this.helper.namespace('Variant_Value__c'), insertVariantValues, this.insertSliceSize)
+      console.log('variant value results: ', JSON.parse(JSON.stringify(results)));
       this.log.addToLogs(results, 'Variant_Value__c')
     }
   }

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -1,16 +1,19 @@
-const XLSX = require('xlsx')
-const { jwtSession, newParser } = require('@propelsoftwaresolutions/propel-sfdc-connect')
+const XLSX = require('xlsx');
+const {
+  jwtSession,
+  newParser
+} = require('@propelsoftwaresolutions/propel-sfdc-connect');
 
 function convertDataByType(data, type) {
-  let returnData = Buffer.from(data, 'base64')
+  let returnData = Buffer.from(data, 'base64');
   if (type == 'xlsx') {
-    const wb = XLSX.read(returnData, { type: "buffer" });
+    const wb = XLSX.read(returnData, { type: 'buffer' });
     const ws = wb.Sheets[wb.SheetNames[0]];
-    returnData = XLSX.utils.sheet_to_csv(ws, { forceQuotes: true })
+    returnData = XLSX.utils.sheet_to_csv(ws, { forceQuotes: true });
   } else {
-    returnData = returnData.toString()
+    returnData = returnData.toString();
   }
-  return newParser(returnData)
+  return newParser(returnData);
 }
 
 async function getSessionId(request) {
@@ -19,16 +22,18 @@ async function getSessionId(request) {
     isTest: request.isTest,
     privateKey: process.env.PIM_DATA_SERVICE_KEY.replace(/\\n/g, '\n'),
     user: request.user
-  })
+  });
   return response;
 }
 
 function convertToCsv(arr) {
-  const array = [Object.keys(arr[0])].concat(arr)
+  const array = [Object.keys(arr[0])].concat(arr);
 
-  return array.map(it => {
-    return Object.values(it).toString()
-  }).join('\n')
+  return array
+    .map(it => {
+      return Object.values(it).toString();
+    })
+    .join('\n');
 }
 
 function prepareIdsForSOQL(idList) {
@@ -47,9 +52,37 @@ function prepareIdsForSOQL(idList) {
   }
 }
 
+/**
+ * Takes in an array of objects and parses any errors in the "errors" field of each object.
+ * Parsing only occurs on results where "success" is false.
+ * Any errors in the format "((error message)))" will be displayed nicely.
+ * Else, it would display the original error message.
+ * @param {Object[]} data 
+ * @returns 
+ */
+function parseResultsForErrors(data) {
+  return data.map(entry => {
+    // Skip processing if success is true
+    if (entry.success === true) {
+      return entry;
+    }
+
+    const extractedErrors = entry.errors?.map(err => {
+      const match = err.match(/\(\(\((.*?)\)\)\)/);
+      return match ? `(((${match[1]})))` : err; // keep original if no match
+    }) ?? [];
+
+    return {
+      ...entry,
+      errors: extractedErrors
+    };
+  });
+}
+
 module.exports = {
   convertDataByType,
   getSessionId,
   convertToCsv,
-  prepareIdsForSOQL
-}
+  prepareIdsForSOQL,
+  parseResultsForErrors
+};

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -56,7 +56,6 @@ function prepareIdsForSOQL(idList) {
  * Takes in an array of objects and parses any errors in the "errors" field of each object.
  * Parsing only occurs on results where "success" is false.
  * Any errors in the format "((error message)))" will be displayed nicely.
- * E.g.: 'caused by: PIMException: (((Product limit reached (10))))' => 'Product limit reached (10)'
  * Else, it would display the original error message.
  * @param {Object[]} data 
  * @returns 
@@ -70,7 +69,7 @@ function parseResultsForErrors(data) {
 
     const extractedErrors = entry.errors?.map(err => {
       const match = err.match(/\(\(\((.*?)\)\)\)/);
-      return match ? match[1] : err; // keep only the inner text
+      return match ? `(((${match[1]})))` : err; // keep original if no match
     }) ?? [];
 
     return {

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -56,6 +56,7 @@ function prepareIdsForSOQL(idList) {
  * Takes in an array of objects and parses any errors in the "errors" field of each object.
  * Parsing only occurs on results where "success" is false.
  * Any errors in the format "((error message)))" will be displayed nicely.
+ * E.g.: 'caused by: PIMException: (((Product limit reached (10))))' => 'Product limit reached (10)'
  * Else, it would display the original error message.
  * @param {Object[]} data 
  * @returns 
@@ -69,7 +70,7 @@ function parseResultsForErrors(data) {
 
     const extractedErrors = entry.errors?.map(err => {
       const match = err.match(/\(\(\((.*?)\)\)\)/);
-      return match ? `(((${match[1]})))` : err; // keep original if no match
+      return match ? match[1] : err; // keep only the inner text
     }) ?? [];
 
     return {


### PR DESCRIPTION
Format the error messages within '(((' and ')))' to display nicely.

**NOTE**: this is **only** for Products and Variant Values. Have yet to do for the others (e.g. Attribute Labels, Tabs, etc) -- we will have to take this into account when building Import 2.0.

E.g.:

```
[
  {
    id: null,
    success: false,
    errors: [
      'CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY:Product: execution of BeforeInsert\n' +
        '\n' +
        'caused by: PIMException: (((Product limit reached (10))))\n' +
        '\n' +
        'Class.ProductTriggerService.throwError: line 192, column 1\n' +
        'Class.ProductTriggerService.checkProductLimit: line 185, column 1\n' +
        'Class.ProductTriggerService.beforeInsert: line 15, column 1\n' +
        'Trigger.Product: line 15, column 1:--'
    ]
  }
]
```

will now display as 

```
[
  {
    "errors": [
      "(((Product limit reached (10)))"
    ],
    "record_id": null,
    "sobject_name": "Product__c",
    "success": false
  }
]
```

**Errors:**

<img width="396" height="342" alt="image" src="https://github.com/user-attachments/assets/788b7801-5792-4917-998b-8d07bc17ffc0" />

**Successes:**

<img width="367" height="306" alt="image" src="https://github.com/user-attachments/assets/8aba16f5-c633-4fc4-b353-daed1f3b77ce" />

