### PR TITLE
PIM-1414: PIM | DA | Uploading a file name greater > 80 Charcters

### DIFF
--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -225,7 +225,7 @@ class ImportAssetMetadata extends ImportClass {
       }
       // if assetName exceeds 80 char (but under 256 char), store it in assetPimName, and truncate assetName
       if (assetName.length > 80) {
-        if (assetPimName?.length === 0) {
+        if (!assetPimName) {
           assetPimName = assetName;
           assetName = assetName.slice(0, 80);
         }

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -122,7 +122,7 @@ class ImportAssetMetadata extends ImportClass {
           this.existingAssetIdMap.has(this.propelParser.nodes[x]['Digital Asset Record'])
         ) {
           const assetSObjectId = this.existingAssetIdMap.get(this.propelParser.nodes[x]['Digital Asset Record']);
-          this.updateAssetCategory(assetSObjectId, this.propelParser.nodes[x]);
+          this.updateAssetCategoryAndPimName(assetSObjectId, this.propelParser.nodes[x]);
           
           this.labelNames.forEach((label) => {
             label = label.slice(1, -1);
@@ -148,13 +148,15 @@ class ImportAssetMetadata extends ImportClass {
     }
   }
 
-  updateAssetCategory(assetSObjectId, parserNode) {
-    if (!parserNode['Category ID'] || !this.categoryMap.has(parserNode['Category ID'])) {
+  updateAssetCategoryAndPimName(assetSObjectId, parserNode) {
+    if (!this.categoryMap.has(parserNode['Category ID']) || parserNode['File Name']?.length > 255) {
       return;
     }
     let tempAsset = new Object();
     tempAsset['Id'] = assetSObjectId;
-    tempAsset[this.helper.namespace('Category__c')] = this.categoryMap.get(parserNode['Category ID']);
+    tempAsset[this.helper.namespace('Category__c')] = parserNode['Category ID'] == null ? null :
+      this.categoryMap.get(parserNode['Category ID']);
+    tempAsset[this.helper.namespace('PIM_Digital_Asset_Name__c')] = parserNode['File Name'];
     this.tempAssetsToUpdate.push(tempAsset);
   }
 
@@ -217,12 +219,21 @@ class ImportAssetMetadata extends ImportClass {
     let tempAssetsToInsert = [];
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
       const assetName = this.propelParser.nodes[x]['Digital Asset Record'];
-      if (!this.newAssetMetadataMap.has(assetName)) {
+      const assetPimName = this.propelParser.nodes[x]['File Name'];
+      if (!this.newAssetMetadataMap.has(assetName) || assetPimName?.length > 255 || assetName?.length > 255) {
         continue;
+      }
+      // if assetName exceeds 80 char (but under 256 char), store it in assetPimName, and truncate assetName
+      if (assetName.length > 80) {
+        if (assetPimName?.length === 0) {
+          assetPimName = assetName;
+          assetName = assetName.slice(0, 80);
+        }
       }
 
       tempAsset = new Object();
       tempAsset['Name'] = assetName;
+      tempAsset[this.helper.namespace('PIM_Digital_Asset_Name__c')] = assetPimName;
       tempAsset[this.helper.namespace('Category__c')] = this.categoryMap.get(this.propelParser.nodes[x]['Category ID']);
       tempAsset[this.helper.namespace('External_File_Id__c')] = 'N.A.';
       tempAsset[this.helper.namespace('Content_Location__c')] = 'N.A.';

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -228,7 +228,7 @@ class ImportAssetMetadata extends ImportClass {
       }
 
       tempAsset = new Object();
-      tempAsset['Name'] = assetName.slice(0, 80);;
+      tempAsset['Name'] = assetName.slice(0, 80);
       tempAsset[this.helper.namespace('PIM_Digital_Asset_Name__c')] = assetPimName;
       tempAsset[this.helper.namespace('Category__c')] = this.categoryMap.get(this.propelParser.nodes[x]['Category ID']);
       tempAsset[this.helper.namespace('External_File_Id__c')] = 'N.A.';

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -154,8 +154,7 @@ class ImportAssetMetadata extends ImportClass {
     }
     let tempAsset = new Object();
     tempAsset['Id'] = assetSObjectId;
-    tempAsset[this.helper.namespace('Category__c')] = parserNode['Category ID'] == null ? null :
-      this.categoryMap.get(parserNode['Category ID']);
+    tempAsset[this.helper.namespace('Category__c')] = this.categoryMap.get(parserNode['Category ID']);
     tempAsset[this.helper.namespace('PIM_Digital_Asset_Name__c')] = parserNode['File Name'];
     this.tempAssetsToUpdate.push(tempAsset);
   }
@@ -223,16 +222,13 @@ class ImportAssetMetadata extends ImportClass {
       if (!this.newAssetMetadataMap.has(assetName) || assetPimName?.length > 255 || assetName?.length > 255) {
         continue;
       }
-      // if assetName exceeds 80 char (but under 256 char), store it in assetPimName, and truncate assetName
-      if (assetName.length > 80) {
-        if (!assetPimName) {
-          assetPimName = assetName;
-          assetName = assetName.slice(0, 80);
-        }
+      // if assetName exceeds 80 char (but under 256 char), store it in assetPimName (provided it is blank)
+      if (assetName.length > 80 && !assetPimName) {
+        assetPimName = assetName;
       }
 
       tempAsset = new Object();
-      tempAsset['Name'] = assetName;
+      tempAsset['Name'] = assetName.slice(0, 80);;
       tempAsset[this.helper.namespace('PIM_Digital_Asset_Name__c')] = assetPimName;
       tempAsset[this.helper.namespace('Category__c')] = this.categoryMap.get(this.propelParser.nodes[x]['Category ID']);
       tempAsset[this.helper.namespace('External_File_Id__c')] = 'N.A.';

--- a/lib/ImportAssetMetadata.js
+++ b/lib/ImportAssetMetadata.js
@@ -218,8 +218,8 @@ class ImportAssetMetadata extends ImportClass {
     let tempAsset;
     let tempAssetsToInsert = [];
     for (let x = 0; x < this.propelParser.nodes.length; x++) {
-      const assetName = this.propelParser.nodes[x]['Digital Asset Record'];
-      const assetPimName = this.propelParser.nodes[x]['File Name'];
+      let assetName = this.propelParser.nodes[x]['Digital Asset Record'];
+      let assetPimName = this.propelParser.nodes[x]['File Name'];
       if (!this.newAssetMetadataMap.has(assetName) || assetPimName?.length > 255 || assetName?.length > 255) {
         continue;
       }


### PR DESCRIPTION
- if File Name value exceeds 255 characters, row is not imported/updated
- if File Name is empty and Digital Asset Record value exceeds 80 characters, PIM_Digital_Asset_Name__c will be populated with the Digital Asset Record value, and then Digital Asset Record value will be truncated to 80 characters before storing in the Name field
- Fixed bug where row update is skipped if no value for category id

PIM PR: https://github.com/PropelPLM/PIM/pull/1751